### PR TITLE
Make `standard_recursion_config()` public

### DIFF
--- a/plonky2/src/plonk/circuit_data.rs
+++ b/plonky2/src/plonk/circuit_data.rs
@@ -122,7 +122,7 @@ impl CircuitConfig {
         }
     }
 
-    fn standard_recursion_config() -> Self {
+    pub fn standard_recursion_config() -> Self {
         Self {
             num_wires: 0,
             num_routed_wires: 80,


### PR DESCRIPTION
This function was made private in 35cfdaa but it's required to be public as the other config functions in `CircuitConfig`.