### PR TITLE
Revert "Make `standard_recursion_config()` public"

### DIFF
--- a/plonky2/src/plonk/circuit_data.rs
+++ b/plonky2/src/plonk/circuit_data.rs
@@ -122,7 +122,7 @@ impl CircuitConfig {
         }
     }
 
-    pub fn standard_recursion_config() -> Self {
+    fn standard_recursion_config() -> Self {
         Self {
             num_wires: 0,
             num_routed_wires: 80,


### PR DESCRIPTION
Reverts telosnetwork/plonky2_goldibear#17.

After merging we noted that making the function private was intentional and not a mistake, as only the other "higher level" functions should be available for third-party code (e.g. `standard_recursion_config_gl()` when using Goldilocks). 