### PR TITLE
Fix Public Inputs Errors

### DIFF
--- a/plonky2/benches/recursion.rs
+++ b/plonky2/benches/recursion.rs
@@ -93,6 +93,8 @@ where
         &input_proof_verifier_data_target,
         input_proof_common_circuit_data,
     );
+    let zero = builder.zero();
+    builder.register_public_input(zero);
     builder.print_gate_counts(0);
 
     let circuit_data = builder.build::<C>();

--- a/plonky2/src/recursion/recursive_verifier.rs
+++ b/plonky2/src/recursion/recursive_verifier.rs
@@ -422,10 +422,10 @@ mod tests {
         assert_eq!(
             vd.circuit_digest.elements,
             [
-                8432421367864141243,
-                14664604448411724612,
-                5886388820728283451,
-                6226320497402393979
+                40392719057770864,
+                9247014007799316719,
+                17436525775388713746,
+                10078131498506678571
             ]
             .map(F::from_canonical_u64)
         );
@@ -443,10 +443,10 @@ mod tests {
         assert_eq!(
             vd.circuit_digest.elements,
             [
-                14839025416225437588,
-                13588008562724358006,
-                4147565255902737239,
-                7805652275147400996
+                13853083556319302030,
+                7032558940778999676,
+                15988113482817466578,
+                3553937068079282312
             ]
             .map(F::from_canonical_u64)
         );
@@ -681,6 +681,8 @@ where {
             }
             _ => panic!(),
         };
+        let zeroes = [builder.zero(); NUM_HASH_OUT_ELTS];
+        builder.register_public_inputs(&zeroes);
         let data = builder.build::<C>();
         let inputs = PartialWitness::new();
         let proof = data.prove(inputs)?;

--- a/plonky2/src/util/serialization/gate_serialization.rs
+++ b/plonky2/src/util/serialization/gate_serialization.rs
@@ -152,7 +152,7 @@ pub mod default {
             NoopGate,
             PoseidonMdsGate<F, D>,
             PoseidonGate<F, D>,
-            PublicInputGate,
+            PublicInputGate<NUM_HASH_OUT_ELTS>,
             RandomAccessGate<F, D>,
             ReducingExtensionGate<D>,
             ReducingGate<D>,


### PR DESCRIPTION
Public Input Gate now take NUM_HASH_OUT_ELTS as parameter. Fixed also an error in the circuit building: the poseidon2 gate used for hashing the public inputs was not finalized.