### PR TITLE
Exported BabyBear and Goldilocks constants for extension degree e number of hash outputs

### DIFF
--- a/field/src/extension_algebra.rs
+++ b/field/src/extension_algebra.rs
@@ -287,10 +287,11 @@ mod tests {
         use p3_goldilocks::Goldilocks;
 
         use super::*;
+        use crate::GOLDILOCKS_EXTENSION_FIELD_DEGREE;
 
         #[test]
         fn test_algebra() {
-            test_extension_algebra::<Goldilocks, 2>();
+            test_extension_algebra::<Goldilocks, GOLDILOCKS_EXTENSION_FIELD_DEGREE>();
         }
     }
 
@@ -298,10 +299,11 @@ mod tests {
         use p3_baby_bear::BabyBear;
 
         use super::*;
+        use crate::BABYBEAR_EXTENSION_FIELD_DEGREE;
 
         #[test]
         fn test_algebra() {
-            test_extension_algebra::<BabyBear, 4>();
+            test_extension_algebra::<BabyBear, BABYBEAR_EXTENSION_FIELD_DEGREE>();
         }
     }
 }

--- a/field/src/field_testing.rs
+++ b/field/src/field_testing.rs
@@ -198,9 +198,11 @@ mod tests {
     mod goldilocks_ext {
         use crate::{test_field_arithmetic, test_field_extension};
 
-        test_field_extension!(p3_goldilocks::Goldilocks, 2);
+        test_field_extension!(p3_goldilocks::Goldilocks, {
+            crate::GOLDILOCKS_EXTENSION_FIELD_DEGREE
+        });
         test_field_arithmetic!(
-            p3_field::extension::BinomialExtensionField<p3_goldilocks::Goldilocks, 2>
+            p3_field::extension::BinomialExtensionField<p3_goldilocks::Goldilocks, {crate::GOLDILOCKS_EXTENSION_FIELD_DEGREE}>
         );
     }
 
@@ -213,9 +215,11 @@ mod tests {
     mod babybear_ext {
         use crate::{test_field_arithmetic, test_field_extension};
 
-        test_field_extension!(p3_baby_bear::BabyBear, 4);
+        test_field_extension!(p3_baby_bear::BabyBear, {
+            crate::BABYBEAR_EXTENSION_FIELD_DEGREE
+        });
         test_field_arithmetic!(
-            p3_field::extension::BinomialExtensionField<p3_baby_bear::BabyBear, 4>
+            p3_field::extension::BinomialExtensionField<p3_baby_bear::BabyBear, {crate::BABYBEAR_EXTENSION_FIELD_DEGREE}>
         );
     }
 }

--- a/field/src/interpolation.rs
+++ b/field/src/interpolation.rs
@@ -87,6 +87,7 @@ mod tests {
     use super::*;
     use crate::polynomial::PolynomialCoeffs;
     use crate::types::{two_adic_subgroup, Sample};
+    use crate::GOLDILOCKS_EXTENSION_FIELD_DEGREE;
 
     #[test]
     fn interpolant_random() {
@@ -138,7 +139,7 @@ mod tests {
 
     #[test]
     fn test_interpolate2() {
-        type F = BinomialExtensionField<Goldilocks, 2>;
+        type F = BinomialExtensionField<Goldilocks, GOLDILOCKS_EXTENSION_FIELD_DEGREE>;
         let points = [(F::rand(), F::rand()), (F::rand(), F::rand())];
         let x = F::rand();
 

--- a/field/src/lib.rs
+++ b/field/src/lib.rs
@@ -10,6 +10,11 @@
     feature(stdarch_x86_avx512)
 )]
 
+pub const GOLDILOCKS_NUM_HASH_OUT_ELTS: usize = 4;
+pub const GOLDILOCKS_EXTENSION_FIELD_DEGREE: usize = 2;
+pub const BABYBEAR_NUM_HASH_OUT_ELTS: usize = 8;
+pub const BABYBEAR_EXTENSION_FIELD_DEGREE: usize = 4;
+
 extern crate alloc;
 
 pub mod batch_util;

--- a/field/src/polynomial/division.rs
+++ b/field/src/polynomial/division.rs
@@ -144,10 +144,11 @@ mod tests {
 
     use crate::polynomial::PolynomialCoeffs;
     use crate::types::Sample;
+    use crate::GOLDILOCKS_EXTENSION_FIELD_DEGREE;
 
     #[test]
     fn test_division_by_linear() {
-        type F = BinomialExtensionField<Goldilocks, 2>;
+        type F = BinomialExtensionField<Goldilocks, GOLDILOCKS_EXTENSION_FIELD_DEGREE>;
         let n = OsRng.gen_range(1..1000);
         let poly = PolynomialCoeffs::new(F::rand_vec(n));
         let z = F::rand();

--- a/plonky2/benches/field_arithmetic.rs
+++ b/plonky2/benches/field_arithmetic.rs
@@ -4,6 +4,7 @@ use p3_field::extension::BinomialExtensionField;
 use p3_field::{batch_multiplicative_inverse, TwoAdicField};
 use p3_goldilocks::Goldilocks;
 use plonky2_field::types::Sample;
+use plonky2_field::{BABYBEAR_EXTENSION_FIELD_DEGREE, GOLDILOCKS_EXTENSION_FIELD_DEGREE};
 use tynm::type_name;
 
 mod allocator;
@@ -188,9 +189,9 @@ pub(crate) fn bench_field<F: TwoAdicField + Sample>(c: &mut Criterion) {
 
 fn criterion_benchmark(c: &mut Criterion) {
     bench_field::<Goldilocks>(c);
-    bench_field::<BinomialExtensionField<Goldilocks, 2>>(c);
+    bench_field::<BinomialExtensionField<Goldilocks, GOLDILOCKS_EXTENSION_FIELD_DEGREE>>(c);
     bench_field::<BabyBear>(c);
-    bench_field::<BinomialExtensionField<BabyBear, 4>>(c);
+    bench_field::<BinomialExtensionField<BabyBear, BABYBEAR_EXTENSION_FIELD_DEGREE>>(c);
 }
 
 criterion_group!(benches, criterion_benchmark);

--- a/plonky2/benches/recursion.rs
+++ b/plonky2/benches/recursion.rs
@@ -17,6 +17,10 @@ use plonky2::plonk::proof::{ProofWithPublicInputs, ProofWithPublicInputsTarget};
 use plonky2::plonk::prover::prove;
 use plonky2::util::proving_process_info::ProvingProcessInfo;
 use plonky2_field::types::HasExtension;
+use plonky2_field::{
+    BABYBEAR_EXTENSION_FIELD_DEGREE, BABYBEAR_NUM_HASH_OUT_ELTS, GOLDILOCKS_EXTENSION_FIELD_DEGREE,
+    GOLDILOCKS_NUM_HASH_OUT_ELTS,
+};
 use tynm::type_name;
 
 mod allocator;
@@ -346,23 +350,31 @@ where
 }
 
 fn criterion_benchmark(c: &mut Criterion) {
-    bench_recursion::<Goldilocks, PoseidonGoldilocksConfig, 2, 4>(
-        c,
-        &CircuitConfig::standard_recursion_config_gl(),
-    );
-    bench_recursion::<BabyBear, Poseidon2BabyBearConfig, 4, 8>(
-        c,
-        &CircuitConfig::standard_recursion_config_bb_wide(),
-    );
+    bench_recursion::<
+        Goldilocks,
+        PoseidonGoldilocksConfig,
+        GOLDILOCKS_EXTENSION_FIELD_DEGREE,
+        GOLDILOCKS_NUM_HASH_OUT_ELTS,
+    >(c, &CircuitConfig::standard_recursion_config_gl());
+    bench_recursion::<
+        BabyBear,
+        Poseidon2BabyBearConfig,
+        BABYBEAR_EXTENSION_FIELD_DEGREE,
+        BABYBEAR_NUM_HASH_OUT_ELTS,
+    >(c, &CircuitConfig::standard_recursion_config_bb_wide());
 
-    bench_merge::<Goldilocks, PoseidonGoldilocksConfig, 2, 4>(
-        c,
-        &CircuitConfig::standard_recursion_config_gl(),
-    );
-    bench_merge::<BabyBear, Poseidon2BabyBearConfig, 4, 8>(
-        c,
-        &CircuitConfig::standard_recursion_config_bb_wide(),
-    );
+    bench_merge::<
+        Goldilocks,
+        PoseidonGoldilocksConfig,
+        GOLDILOCKS_EXTENSION_FIELD_DEGREE,
+        GOLDILOCKS_NUM_HASH_OUT_ELTS,
+    >(c, &CircuitConfig::standard_recursion_config_gl());
+    bench_merge::<
+        BabyBear,
+        Poseidon2BabyBearConfig,
+        BABYBEAR_EXTENSION_FIELD_DEGREE,
+        BABYBEAR_NUM_HASH_OUT_ELTS,
+    >(c, &CircuitConfig::standard_recursion_config_bb_wide());
 }
 
 criterion_group!(benches, criterion_benchmark);

--- a/plonky2/examples/bench_recursion.rs
+++ b/plonky2/examples/bench_recursion.rs
@@ -33,6 +33,10 @@ use plonky2::plonk::prover::prove;
 use plonky2::util::proving_process_info::ProvingProcessInfo;
 use plonky2::util::serialization::DefaultGateSerializer;
 use plonky2_field::types::HasExtension;
+use plonky2_field::{
+    BABYBEAR_EXTENSION_FIELD_DEGREE, BABYBEAR_NUM_HASH_OUT_ELTS, GOLDILOCKS_EXTENSION_FIELD_DEGREE,
+    GOLDILOCKS_NUM_HASH_OUT_ELTS,
+};
 use plonky2_maybe_rayon::rayon;
 use rand::rngs::OsRng;
 use rand::{RngCore, SeedableRng};
@@ -400,12 +404,18 @@ fn main() -> Result<()> {
     };
     builder.try_init()?;
 
-    do_bench::<BabyBear, Poseidon2BabyBearConfig, 4, 8>(
-        CircuitConfig::standard_recursion_config_bb_wide(),
-    )?;
-    do_bench::<Goldilocks, PoseidonGoldilocksConfig, 2, 4>(
-        CircuitConfig::standard_recursion_config_gl(),
-    )
+    do_bench::<
+        BabyBear,
+        Poseidon2BabyBearConfig,
+        BABYBEAR_EXTENSION_FIELD_DEGREE,
+        BABYBEAR_NUM_HASH_OUT_ELTS,
+    >(CircuitConfig::standard_recursion_config_bb_wide())?;
+    do_bench::<
+        Goldilocks,
+        PoseidonGoldilocksConfig,
+        GOLDILOCKS_EXTENSION_FIELD_DEGREE,
+        GOLDILOCKS_NUM_HASH_OUT_ELTS,
+    >(CircuitConfig::standard_recursion_config_gl())
 }
 fn do_bench<
     F: RichField + HasExtension<D>,

--- a/plonky2/examples/factorial.rs
+++ b/plonky2/examples/factorial.rs
@@ -1,16 +1,16 @@
 use anyhow::Result;
 use p3_field::AbstractField;
-use plonky2::hash::hash_types::GOLDILOCKS_NUM_HASH_OUT_ELTS;
 use plonky2::iop::witness::{PartialWitness, WitnessWrite};
 use plonky2::plonk::circuit_builder::CircuitBuilder;
 use plonky2::plonk::circuit_data::CircuitConfig;
 use plonky2::plonk::config::{GenericConfig, PoseidonGoldilocksConfig};
+use plonky2_field::{GOLDILOCKS_EXTENSION_FIELD_DEGREE, GOLDILOCKS_NUM_HASH_OUT_ELTS};
 
 /// An example of using Plonky2 to prove a statement of the form
 /// "I know n * (n + 1) * ... * (n + 99)".
 /// When n == 1, this is proving knowledge of 100!.
 fn main() -> Result<()> {
-    const D: usize = 2;
+    const D: usize = GOLDILOCKS_EXTENSION_FIELD_DEGREE;
     const NUM_HASH_OUT_ELTS: usize = GOLDILOCKS_NUM_HASH_OUT_ELTS;
     type C = PoseidonGoldilocksConfig;
     type F = <C as GenericConfig<D, NUM_HASH_OUT_ELTS>>::F;

--- a/plonky2/examples/fibonacci.rs
+++ b/plonky2/examples/fibonacci.rs
@@ -1,16 +1,16 @@
 use anyhow::Result;
 use p3_field::AbstractField;
-use plonky2::hash::hash_types::GOLDILOCKS_NUM_HASH_OUT_ELTS;
 use plonky2::iop::witness::{PartialWitness, WitnessWrite};
 use plonky2::plonk::circuit_builder::CircuitBuilder;
 use plonky2::plonk::circuit_data::CircuitConfig;
 use plonky2::plonk::config::{GenericConfig, PoseidonGoldilocksConfig};
+use plonky2_field::{GOLDILOCKS_EXTENSION_FIELD_DEGREE, GOLDILOCKS_NUM_HASH_OUT_ELTS};
 
 /// An example of using Plonky2 to prove a statement of the form
 /// "I know the 100th element of the Fibonacci sequence, starting with constants a and b."
 /// When a == 0 and b == 1, this is proving knowledge of the 100th (standard) Fibonacci number.
 fn main() -> Result<()> {
-    const D: usize = 2;
+    const D: usize = GOLDILOCKS_EXTENSION_FIELD_DEGREE;
     const NUM_HASH_OUT_ELTS: usize = GOLDILOCKS_NUM_HASH_OUT_ELTS;
     type C = PoseidonGoldilocksConfig;
     type F = <C as GenericConfig<D, NUM_HASH_OUT_ELTS>>::F;

--- a/plonky2/examples/fibonacci_serialization.rs
+++ b/plonky2/examples/fibonacci_serialization.rs
@@ -2,18 +2,18 @@ use std::fs;
 
 use anyhow::Result;
 use p3_field::AbstractField;
-use plonky2::hash::hash_types::GOLDILOCKS_NUM_HASH_OUT_ELTS;
 use plonky2::iop::witness::{PartialWitness, WitnessWrite};
 use plonky2::plonk::circuit_builder::CircuitBuilder;
 use plonky2::plonk::circuit_data::CircuitConfig;
 use plonky2::plonk::config::{GenericConfig, PoseidonGoldilocksConfig};
+use plonky2_field::{GOLDILOCKS_EXTENSION_FIELD_DEGREE, GOLDILOCKS_NUM_HASH_OUT_ELTS};
 
 /// An example of using Plonky2 to prove a statement of the form
 /// "I know the 100th element of the Fibonacci sequence, starting with constants a and b."
 /// When a == 0 and b == 1, this is proving knowledge of the 100th (standard) Fibonacci number.
 /// This example also serializes the circuit data and proof to JSON files.
 fn main() -> Result<()> {
-    const D: usize = 2;
+    const D: usize = GOLDILOCKS_EXTENSION_FIELD_DEGREE;
     const NUM_HASH_OUT_ELTS: usize = GOLDILOCKS_NUM_HASH_OUT_ELTS;
     type C = PoseidonGoldilocksConfig;
     type F = <C as GenericConfig<D, NUM_HASH_OUT_ELTS>>::F;

--- a/plonky2/examples/range_check.rs
+++ b/plonky2/examples/range_check.rs
@@ -1,14 +1,14 @@
 use anyhow::Result;
 use p3_field::AbstractField;
-use plonky2::hash::hash_types::GOLDILOCKS_NUM_HASH_OUT_ELTS;
 use plonky2::iop::witness::{PartialWitness, WitnessWrite};
 use plonky2::plonk::circuit_builder::CircuitBuilder;
 use plonky2::plonk::circuit_data::CircuitConfig;
 use plonky2::plonk::config::{GenericConfig, PoseidonGoldilocksConfig};
+use plonky2_field::{GOLDILOCKS_EXTENSION_FIELD_DEGREE, GOLDILOCKS_NUM_HASH_OUT_ELTS};
 
 /// An example of using Plonky2 to prove that a given value lies in a given range.
 fn main() -> Result<()> {
-    const D: usize = 2;
+    const D: usize = GOLDILOCKS_EXTENSION_FIELD_DEGREE;
     const NUM_HASH_OUT_ELTS: usize = GOLDILOCKS_NUM_HASH_OUT_ELTS;
     type C = PoseidonGoldilocksConfig;
     type F = <C as GenericConfig<D, NUM_HASH_OUT_ELTS>>::F;

--- a/plonky2/examples/square_root.rs
+++ b/plonky2/examples/square_root.rs
@@ -5,7 +5,7 @@ use p3_field::{PrimeField64, TwoAdicField};
 use plonky2::gates::arithmetic_base::ArithmeticBaseGenerator;
 use plonky2::gates::poseidon_goldilocks::PoseidonGenerator;
 use plonky2::gates::poseidon_goldilocks_mds::PoseidonMdsGenerator;
-use plonky2::hash::hash_types::{RichField, GOLDILOCKS_NUM_HASH_OUT_ELTS};
+use plonky2::hash::hash_types::RichField;
 use plonky2::iop::generator::{
     ConstantGenerator, GeneratedValues, RandomValueGenerator, SimpleGenerator,
 };
@@ -20,6 +20,7 @@ use plonky2::util::serialization::{
 };
 use plonky2::{get_generator_tag_impl, impl_generator_serializer, read_generator_impl};
 use plonky2_field::types::{HasExtension, Sample};
+use plonky2_field::{GOLDILOCKS_EXTENSION_FIELD_DEGREE, GOLDILOCKS_NUM_HASH_OUT_ELTS};
 
 /// A generator used by the prover to calculate the square root (`x`) of a given value
 /// (`x_squared`), outside of the circuit, in order to supply it as an additional public input.
@@ -105,7 +106,7 @@ where
 /// An example of using Plonky2 to prove a statement of the form
 /// "I know the square root of this field element."
 fn main() -> Result<()> {
-    const D: usize = 2;
+    const D: usize = GOLDILOCKS_EXTENSION_FIELD_DEGREE;
     const NUM_HASH_OUT_ELTS: usize = GOLDILOCKS_NUM_HASH_OUT_ELTS;
     type C = PoseidonGoldilocksConfig;
     type F = <C as GenericConfig<D, NUM_HASH_OUT_ELTS>>::F;

--- a/plonky2/src/gadgets/arithmetic_extension.rs
+++ b/plonky2/src/gadgets/arithmetic_extension.rs
@@ -614,9 +614,9 @@ mod tests {
     use anyhow::Result;
     use plonky2_field::extension_algebra::ExtensionAlgebra;
     use plonky2_field::types::HasExtension;
+    use plonky2_field::{GOLDILOCKS_EXTENSION_FIELD_DEGREE, GOLDILOCKS_NUM_HASH_OUT_ELTS};
 
     use crate::field::types::Sample;
-    use crate::hash::hash_types::GOLDILOCKS_NUM_HASH_OUT_ELTS;
     use crate::iop::ext_target::ExtensionAlgebraTarget;
     use crate::iop::witness::{PartialWitness, WitnessWrite};
     use crate::plonk::circuit_builder::CircuitBuilder;
@@ -626,7 +626,7 @@ mod tests {
 
     #[test]
     fn test_mul_many() -> Result<()> {
-        const D: usize = 2;
+        const D: usize = GOLDILOCKS_EXTENSION_FIELD_DEGREE;
         type C = PoseidonGoldilocksConfig;
         const NUM_HASH_OUT_ELTS: usize = GOLDILOCKS_NUM_HASH_OUT_ELTS;
         type F = <C as GenericConfig<D, NUM_HASH_OUT_ELTS>>::F;
@@ -663,7 +663,7 @@ mod tests {
 
     #[test]
     fn test_div_extension() -> Result<()> {
-        const D: usize = 2;
+        const D: usize = GOLDILOCKS_EXTENSION_FIELD_DEGREE;
         type C = PoseidonGoldilocksConfig;
         const NUM_HASH_OUT_ELTS: usize = GOLDILOCKS_NUM_HASH_OUT_ELTS;
         type F = <C as GenericConfig<D, NUM_HASH_OUT_ELTS>>::F;
@@ -691,7 +691,7 @@ mod tests {
 
     #[test]
     fn test_mul_algebra() -> Result<()> {
-        const D: usize = 2;
+        const D: usize = GOLDILOCKS_EXTENSION_FIELD_DEGREE;
         type C = KeccakGoldilocksConfig;
         const NUM_HASH_OUT_ELTS: usize = GOLDILOCKS_NUM_HASH_OUT_ELTS;
         type F = <C as GenericConfig<D, NUM_HASH_OUT_ELTS>>::F;

--- a/plonky2/src/gadgets/interpolation.rs
+++ b/plonky2/src/gadgets/interpolation.rs
@@ -47,11 +47,11 @@ mod tests {
     use anyhow::Result;
     use p3_field::{cyclic_subgroup_coset_known_order, AbstractExtensionField, TwoAdicField};
     use plonky2_field::types::HasExtension;
+    use plonky2_field::{GOLDILOCKS_EXTENSION_FIELD_DEGREE, GOLDILOCKS_NUM_HASH_OUT_ELTS};
 
     use crate::field::interpolation::interpolant;
     use crate::field::types::Sample;
     use crate::gates::coset_interpolation::CosetInterpolationGate;
-    use crate::hash::hash_types::GOLDILOCKS_NUM_HASH_OUT_ELTS;
     use crate::iop::witness::PartialWitness;
     use crate::plonk::circuit_builder::CircuitBuilder;
     use crate::plonk::circuit_data::CircuitConfig;
@@ -60,7 +60,7 @@ mod tests {
 
     #[test]
     fn test_interpolate() -> Result<()> {
-        const D: usize = 2;
+        const D: usize = GOLDILOCKS_EXTENSION_FIELD_DEGREE;
         type C = PoseidonGoldilocksConfig;
         const NUM_HASH_OUT_ELTS: usize = GOLDILOCKS_NUM_HASH_OUT_ELTS;
         type F = <C as GenericConfig<D, NUM_HASH_OUT_ELTS>>::F;

--- a/plonky2/src/gadgets/random_access.rs
+++ b/plonky2/src/gadgets/random_access.rs
@@ -107,17 +107,17 @@ impl<F: RichField + HasExtension<D>, const D: usize, const NUM_HASH_OUT_ELTS: us
 mod tests {
     use anyhow::Result;
     use p3_field::AbstractField;
+    use plonky2_field::{GOLDILOCKS_EXTENSION_FIELD_DEGREE, GOLDILOCKS_NUM_HASH_OUT_ELTS};
 
     use super::*;
     use crate::field::types::Sample;
-    use crate::hash::hash_types::GOLDILOCKS_NUM_HASH_OUT_ELTS;
     use crate::iop::witness::PartialWitness;
     use crate::plonk::circuit_data::CircuitConfig;
     use crate::plonk::config::{GenericConfig, PoseidonGoldilocksConfig};
     use crate::plonk::verifier::verify;
 
     fn test_random_access_given_len(len_log: usize) -> Result<()> {
-        const D: usize = 2;
+        const D: usize = GOLDILOCKS_EXTENSION_FIELD_DEGREE;
         type C = PoseidonGoldilocksConfig;
         const NUM_HASH_OUT_ELTS: usize = GOLDILOCKS_NUM_HASH_OUT_ELTS;
         type F = <C as GenericConfig<D, NUM_HASH_OUT_ELTS>>::F;

--- a/plonky2/src/gadgets/select.rs
+++ b/plonky2/src/gadgets/select.rs
@@ -42,9 +42,9 @@ impl<F: RichField + HasExtension<D>, const D: usize, const NUM_HASH_OUT_ELTS: us
 #[cfg(test)]
 mod tests {
     use anyhow::Result;
+    use plonky2_field::{GOLDILOCKS_EXTENSION_FIELD_DEGREE, GOLDILOCKS_NUM_HASH_OUT_ELTS};
 
     use crate::field::types::Sample;
-    use crate::hash::hash_types::GOLDILOCKS_NUM_HASH_OUT_ELTS;
     use crate::iop::witness::{PartialWitness, WitnessWrite};
     use crate::plonk::circuit_builder::CircuitBuilder;
     use crate::plonk::circuit_data::CircuitConfig;
@@ -53,7 +53,7 @@ mod tests {
 
     #[test]
     fn test_select() -> Result<()> {
-        const D: usize = 2;
+        const D: usize = GOLDILOCKS_EXTENSION_FIELD_DEGREE;
         type C = PoseidonGoldilocksConfig;
         const NUM_HASH_OUT_ELTS: usize = GOLDILOCKS_NUM_HASH_OUT_ELTS;
         type F = <C as GenericConfig<D, NUM_HASH_OUT_ELTS>>::F;

--- a/plonky2/src/gadgets/split_base.rs
+++ b/plonky2/src/gadgets/split_base.rs
@@ -138,11 +138,11 @@ impl<
 mod tests {
     use anyhow::Result;
     use p3_field::AbstractField;
+    use plonky2_field::{GOLDILOCKS_EXTENSION_FIELD_DEGREE, GOLDILOCKS_NUM_HASH_OUT_ELTS};
     use rand::rngs::OsRng;
     use rand::Rng;
 
     use super::*;
-    use crate::hash::hash_types::GOLDILOCKS_NUM_HASH_OUT_ELTS;
     use crate::iop::witness::PartialWitness;
     use crate::plonk::circuit_data::CircuitConfig;
     use crate::plonk::config::{GenericConfig, PoseidonGoldilocksConfig};
@@ -150,7 +150,7 @@ mod tests {
 
     #[test]
     fn test_split_base() -> Result<()> {
-        const D: usize = 2;
+        const D: usize = GOLDILOCKS_EXTENSION_FIELD_DEGREE;
         type C = PoseidonGoldilocksConfig;
         const NUM_HASH_OUT_ELTS: usize = GOLDILOCKS_NUM_HASH_OUT_ELTS;
         type F = <C as GenericConfig<D, NUM_HASH_OUT_ELTS>>::F;
@@ -179,7 +179,7 @@ mod tests {
 
     #[test]
     fn test_base_sum() -> Result<()> {
-        const D: usize = 2;
+        const D: usize = GOLDILOCKS_EXTENSION_FIELD_DEGREE;
         type C = PoseidonGoldilocksConfig;
         const NUM_HASH_OUT_ELTS: usize = GOLDILOCKS_NUM_HASH_OUT_ELTS;
         type F = <C as GenericConfig<D, NUM_HASH_OUT_ELTS>>::F;

--- a/plonky2/src/gates/add_many.rs
+++ b/plonky2/src/gates/add_many.rs
@@ -234,10 +234,10 @@ impl<F: RichField + HasExtension<D>, const D: usize, const NUM_HASH_OUT_ELTS: us
 mod tests {
     use anyhow::Result;
     use p3_goldilocks::Goldilocks;
+    use plonky2_field::{GOLDILOCKS_EXTENSION_FIELD_DEGREE, GOLDILOCKS_NUM_HASH_OUT_ELTS};
 
     use super::AddManyGate;
     use crate::gates::gate_testing::{test_eval_fns, test_low_degree};
-    use crate::hash::hash_types::GOLDILOCKS_NUM_HASH_OUT_ELTS;
     use crate::plonk::circuit_data::CircuitConfig;
     use crate::plonk::config::{GenericConfig, PoseidonGoldilocksConfig};
 
@@ -247,12 +247,17 @@ mod tests {
             &CircuitConfig::standard_recursion_config_gl(),
             32,
         );
-        test_low_degree::<Goldilocks, _, 2, 4>(gate);
+        test_low_degree::<
+            Goldilocks,
+            _,
+            GOLDILOCKS_EXTENSION_FIELD_DEGREE,
+            GOLDILOCKS_NUM_HASH_OUT_ELTS,
+        >(gate);
     }
 
     #[test]
     fn eval_fns() -> Result<()> {
-        const D: usize = 2;
+        const D: usize = GOLDILOCKS_EXTENSION_FIELD_DEGREE;
         type C = PoseidonGoldilocksConfig;
         const NUM_HASH_OUT_ELTS: usize = GOLDILOCKS_NUM_HASH_OUT_ELTS;
         type F = <C as GenericConfig<D, NUM_HASH_OUT_ELTS>>::F;

--- a/plonky2/src/gates/apply_mat4.rs
+++ b/plonky2/src/gates/apply_mat4.rs
@@ -292,22 +292,24 @@ impl<F: RichField + HasExtension<D>, const D: usize, const NUM_HASH_OUT_ELTS: us
 mod tests {
     use anyhow::Result;
     use p3_baby_bear::BabyBear;
+    use plonky2_field::{BABYBEAR_EXTENSION_FIELD_DEGREE, BABYBEAR_NUM_HASH_OUT_ELTS};
 
     use crate::gates::arithmetic_base::ArithmeticGate;
     use crate::gates::gate_testing::{test_eval_fns, test_low_degree};
-    use crate::hash::hash_types::BABYBEAR_NUM_HASH_OUT_ELTS;
     use crate::plonk::circuit_data::CircuitConfig;
     use crate::plonk::config::{GenericConfig, Poseidon2BabyBearConfig};
 
     #[test]
     fn low_degree() {
         let gate = ArithmeticGate::new_from_config(&CircuitConfig::standard_recursion_config_gl());
-        test_low_degree::<BabyBear, _, 4, 8>(gate);
+        test_low_degree::<BabyBear, _, BABYBEAR_EXTENSION_FIELD_DEGREE, BABYBEAR_NUM_HASH_OUT_ELTS>(
+            gate,
+        );
     }
 
     #[test]
     fn eval_fns() -> Result<()> {
-        const D: usize = 4;
+        const D: usize = BABYBEAR_EXTENSION_FIELD_DEGREE;
         type C = Poseidon2BabyBearConfig;
         const NUM_HASH_OUT_ELTS: usize = BABYBEAR_NUM_HASH_OUT_ELTS;
         type F = <C as GenericConfig<D, NUM_HASH_OUT_ELTS>>::F;

--- a/plonky2/src/gates/arithmetic_base.rs
+++ b/plonky2/src/gates/arithmetic_base.rs
@@ -275,22 +275,27 @@ impl<F: RichField + HasExtension<D>, const D: usize, const NUM_HASH_OUT_ELTS: us
 mod tests {
     use anyhow::Result;
     use p3_goldilocks::Goldilocks;
+    use plonky2_field::{GOLDILOCKS_EXTENSION_FIELD_DEGREE, GOLDILOCKS_NUM_HASH_OUT_ELTS};
 
     use crate::gates::arithmetic_base::ArithmeticGate;
     use crate::gates::gate_testing::{test_eval_fns, test_low_degree};
-    use crate::hash::hash_types::GOLDILOCKS_NUM_HASH_OUT_ELTS;
     use crate::plonk::circuit_data::CircuitConfig;
     use crate::plonk::config::{GenericConfig, PoseidonGoldilocksConfig};
 
     #[test]
     fn low_degree() {
         let gate = ArithmeticGate::new_from_config(&CircuitConfig::standard_recursion_config_gl());
-        test_low_degree::<Goldilocks, _, 2, 4>(gate);
+        test_low_degree::<
+            Goldilocks,
+            _,
+            GOLDILOCKS_EXTENSION_FIELD_DEGREE,
+            GOLDILOCKS_NUM_HASH_OUT_ELTS,
+        >(gate);
     }
 
     #[test]
     fn eval_fns() -> Result<()> {
-        const D: usize = 2;
+        const D: usize = GOLDILOCKS_EXTENSION_FIELD_DEGREE;
         type C = PoseidonGoldilocksConfig;
         const NUM_HASH_OUT_ELTS: usize = GOLDILOCKS_NUM_HASH_OUT_ELTS;
         type F = <C as GenericConfig<D, NUM_HASH_OUT_ELTS>>::F;

--- a/plonky2/src/gates/arithmetic_extension.rs
+++ b/plonky2/src/gates/arithmetic_extension.rs
@@ -271,10 +271,10 @@ impl<F: RichField + HasExtension<D>, const D: usize, const NUM_HASH_OUT_ELTS: us
 mod tests {
     use anyhow::Result;
     use p3_goldilocks::Goldilocks;
+    use plonky2_field::{GOLDILOCKS_EXTENSION_FIELD_DEGREE, GOLDILOCKS_NUM_HASH_OUT_ELTS};
 
     use crate::gates::arithmetic_extension::ArithmeticExtensionGate;
     use crate::gates::gate_testing::{test_eval_fns, test_low_degree};
-    use crate::hash::hash_types::GOLDILOCKS_NUM_HASH_OUT_ELTS;
     use crate::plonk::circuit_data::CircuitConfig;
     use crate::plonk::config::{GenericConfig, PoseidonGoldilocksConfig};
 
@@ -283,12 +283,17 @@ mod tests {
         let gate = ArithmeticExtensionGate::new_from_config(
             &CircuitConfig::standard_recursion_config_gl(),
         );
-        test_low_degree::<Goldilocks, _, 2, 4>(gate);
+        test_low_degree::<
+            Goldilocks,
+            _,
+            GOLDILOCKS_EXTENSION_FIELD_DEGREE,
+            GOLDILOCKS_NUM_HASH_OUT_ELTS,
+        >(gate);
     }
 
     #[test]
     fn eval_fns() -> Result<()> {
-        const D: usize = 2;
+        const D: usize = GOLDILOCKS_EXTENSION_FIELD_DEGREE;
         type C = PoseidonGoldilocksConfig;
         const NUM_HASH_OUT_ELTS: usize = GOLDILOCKS_NUM_HASH_OUT_ELTS;
         type F = <C as GenericConfig<D, NUM_HASH_OUT_ELTS>>::F;

--- a/plonky2/src/gates/base_sum.rs
+++ b/plonky2/src/gates/base_sum.rs
@@ -264,20 +264,25 @@ impl<
 mod tests {
     use anyhow::Result;
     use p3_goldilocks::Goldilocks;
+    use plonky2_field::{GOLDILOCKS_EXTENSION_FIELD_DEGREE, GOLDILOCKS_NUM_HASH_OUT_ELTS};
 
     use crate::gates::base_sum::BaseSumGate;
     use crate::gates::gate_testing::{test_eval_fns, test_low_degree};
-    use crate::hash::hash_types::GOLDILOCKS_NUM_HASH_OUT_ELTS;
     use crate::plonk::config::{GenericConfig, PoseidonGoldilocksConfig};
 
     #[test]
     fn low_degree() {
-        test_low_degree::<Goldilocks, _, 2, 4>(BaseSumGate::<6>::new(11))
+        test_low_degree::<
+            Goldilocks,
+            _,
+            GOLDILOCKS_EXTENSION_FIELD_DEGREE,
+            GOLDILOCKS_NUM_HASH_OUT_ELTS,
+        >(BaseSumGate::<6>::new(11))
     }
 
     #[test]
     fn eval_fns() -> Result<()> {
-        const D: usize = 2;
+        const D: usize = GOLDILOCKS_EXTENSION_FIELD_DEGREE;
         type C = PoseidonGoldilocksConfig;
         const NUM_HASH_OUT_ELTS: usize = GOLDILOCKS_NUM_HASH_OUT_ELTS;
         type F = <C as GenericConfig<D, NUM_HASH_OUT_ELTS>>::F;

--- a/plonky2/src/gates/constant.rs
+++ b/plonky2/src/gates/constant.rs
@@ -151,10 +151,10 @@ impl<F: RichField + HasExtension<D>, const D: usize, const NUM_HASH_OUT_ELTS: us
 mod tests {
     use anyhow::Result;
     use p3_goldilocks::Goldilocks;
+    use plonky2_field::{GOLDILOCKS_EXTENSION_FIELD_DEGREE, GOLDILOCKS_NUM_HASH_OUT_ELTS};
 
     use crate::gates::constant::ConstantGate;
     use crate::gates::gate_testing::{test_eval_fns, test_low_degree};
-    use crate::hash::hash_types::GOLDILOCKS_NUM_HASH_OUT_ELTS;
     use crate::plonk::circuit_data::CircuitConfig;
     use crate::plonk::config::{GenericConfig, PoseidonGoldilocksConfig};
 
@@ -162,12 +162,17 @@ mod tests {
     fn low_degree() {
         let num_consts = CircuitConfig::standard_recursion_config_gl().num_constants;
         let gate = ConstantGate { num_consts };
-        test_low_degree::<Goldilocks, _, 2, 4>(gate)
+        test_low_degree::<
+            Goldilocks,
+            _,
+            GOLDILOCKS_EXTENSION_FIELD_DEGREE,
+            GOLDILOCKS_NUM_HASH_OUT_ELTS,
+        >(gate)
     }
 
     #[test]
     fn eval_fns() -> Result<()> {
-        const D: usize = 2;
+        const D: usize = GOLDILOCKS_EXTENSION_FIELD_DEGREE;
         type C = PoseidonGoldilocksConfig;
         const NUM_HASH_OUT_ELTS: usize = GOLDILOCKS_NUM_HASH_OUT_ELTS;
         type F = <C as GenericConfig<D, NUM_HASH_OUT_ELTS>>::F;

--- a/plonky2/src/gates/coset_interpolation.rs
+++ b/plonky2/src/gates/coset_interpolation.rs
@@ -725,7 +725,8 @@ mod tests {
     #[test]
     fn test_degree_and_wires_minimized() {
         const NUM_HASH_OUT_ELTS: usize = GOLDILOCKS_NUM_HASH_OUT_ELTS;
-        let gate = <CosetInterpolationGate<Goldilocks, GOLDILOCKS_EXTENSION_FIELD_DEGREE>>::with_max_degree(3, 2);
+        const D: usize = GOLDILOCKS_EXTENSION_FIELD_DEGREE;
+        let gate = <CosetInterpolationGate<Goldilocks, D>>::with_max_degree(3, 2);
         assert_eq!(gate.num_intermediates(), 6);
         assert_eq!(
             <CosetInterpolationGate<Goldilocks, GOLDILOCKS_EXTENSION_FIELD_DEGREE> as Gate<
@@ -1014,7 +1015,8 @@ mod tests {
     #[test]
     fn test_num_wires_constraints() {
         const NUM_HASH_OUT_ELTS: usize = GOLDILOCKS_NUM_HASH_OUT_ELTS;
-        let gate = <CosetInterpolationGate<Goldilocks, GOLDILOCKS_EXTENSION_FIELD_DEGREE>>::with_max_degree(4, 8);
+        const D: usize = GOLDILOCKS_EXTENSION_FIELD_DEGREE;
+        let gate = <CosetInterpolationGate<Goldilocks, D>>::with_max_degree(4, 8);
         assert_eq!(
             <CosetInterpolationGate<Goldilocks, GOLDILOCKS_EXTENSION_FIELD_DEGREE> as Gate<
                 Goldilocks,

--- a/plonky2/src/gates/coset_interpolation.rs
+++ b/plonky2/src/gates/coset_interpolation.rs
@@ -713,63 +713,134 @@ mod tests {
     use p3_field::AbstractField;
     use p3_goldilocks::Goldilocks;
     use plonky2_field::polynomial::PolynomialValues;
+    use plonky2_field::{GOLDILOCKS_EXTENSION_FIELD_DEGREE, GOLDILOCKS_NUM_HASH_OUT_ELTS};
     use plonky2_util::log2_strict;
 
     use super::*;
     use crate::field::types::Sample;
     use crate::gates::gate_testing::{test_eval_fns, test_low_degree};
-    use crate::hash::hash_types::{HashOut, GOLDILOCKS_NUM_HASH_OUT_ELTS};
+    use crate::hash::hash_types::HashOut;
     use crate::plonk::config::{GenericConfig, PoseidonGoldilocksConfig};
 
     #[test]
     fn test_degree_and_wires_minimized() {
         const NUM_HASH_OUT_ELTS: usize = GOLDILOCKS_NUM_HASH_OUT_ELTS;
-        let gate = <CosetInterpolationGate<Goldilocks, 2>>::with_max_degree(3, 2);
+        let gate = <CosetInterpolationGate<Goldilocks, GOLDILOCKS_EXTENSION_FIELD_DEGREE>>::with_max_degree(3, 2);
         assert_eq!(gate.num_intermediates(), 6);
-        assert_eq!(<CosetInterpolationGate<Goldilocks, 2> as Gate<Goldilocks, 2, NUM_HASH_OUT_ELTS>>::degree(&gate), 2);
+        assert_eq!(
+            <CosetInterpolationGate<Goldilocks, GOLDILOCKS_EXTENSION_FIELD_DEGREE> as Gate<
+                Goldilocks,
+                GOLDILOCKS_EXTENSION_FIELD_DEGREE,
+                NUM_HASH_OUT_ELTS,
+            >>::degree(&gate),
+            2
+        );
 
-        let gate = <CosetInterpolationGate<Goldilocks, 2>>::with_max_degree(3, 3);
+        let gate = <CosetInterpolationGate<Goldilocks, GOLDILOCKS_EXTENSION_FIELD_DEGREE>>::with_max_degree(3, 3);
         assert_eq!(gate.num_intermediates(), 3);
-        assert_eq!(<CosetInterpolationGate<Goldilocks, 2> as Gate<Goldilocks, 2, NUM_HASH_OUT_ELTS>>::degree(&gate), 3);
+        assert_eq!(
+            <CosetInterpolationGate<Goldilocks, GOLDILOCKS_EXTENSION_FIELD_DEGREE> as Gate<
+                Goldilocks,
+                GOLDILOCKS_EXTENSION_FIELD_DEGREE,
+                NUM_HASH_OUT_ELTS,
+            >>::degree(&gate),
+            3
+        );
 
-        let gate = <CosetInterpolationGate<Goldilocks, 2>>::with_max_degree(3, 4);
+        let gate = <CosetInterpolationGate<Goldilocks, GOLDILOCKS_EXTENSION_FIELD_DEGREE>>::with_max_degree(3, 4);
         assert_eq!(gate.num_intermediates(), 2);
-        assert_eq!(<CosetInterpolationGate<Goldilocks, 2> as Gate<Goldilocks, 2, NUM_HASH_OUT_ELTS>>::degree(&gate), 4);
+        assert_eq!(
+            <CosetInterpolationGate<Goldilocks, GOLDILOCKS_EXTENSION_FIELD_DEGREE> as Gate<
+                Goldilocks,
+                GOLDILOCKS_EXTENSION_FIELD_DEGREE,
+                NUM_HASH_OUT_ELTS,
+            >>::degree(&gate),
+            4
+        );
 
-        let gate = <CosetInterpolationGate<Goldilocks, 2>>::with_max_degree(3, 5);
+        let gate = <CosetInterpolationGate<Goldilocks, GOLDILOCKS_EXTENSION_FIELD_DEGREE>>::with_max_degree(3, 5);
         assert_eq!(gate.num_intermediates(), 1);
-        assert_eq!(<CosetInterpolationGate<Goldilocks, 2> as Gate<Goldilocks, 2, NUM_HASH_OUT_ELTS>>::degree(&gate), 5);
+        assert_eq!(
+            <CosetInterpolationGate<Goldilocks, GOLDILOCKS_EXTENSION_FIELD_DEGREE> as Gate<
+                Goldilocks,
+                GOLDILOCKS_EXTENSION_FIELD_DEGREE,
+                NUM_HASH_OUT_ELTS,
+            >>::degree(&gate),
+            5
+        );
 
-        let gate = <CosetInterpolationGate<Goldilocks, 2>>::with_max_degree(3, 6);
+        let gate = <CosetInterpolationGate<Goldilocks, GOLDILOCKS_EXTENSION_FIELD_DEGREE>>::with_max_degree(3, 6);
         assert_eq!(gate.num_intermediates(), 1);
-        assert_eq!(<CosetInterpolationGate<Goldilocks, 2> as Gate<Goldilocks, 2, NUM_HASH_OUT_ELTS>>::degree(&gate), 5);
+        assert_eq!(
+            <CosetInterpolationGate<Goldilocks, GOLDILOCKS_EXTENSION_FIELD_DEGREE> as Gate<
+                Goldilocks,
+                GOLDILOCKS_EXTENSION_FIELD_DEGREE,
+                NUM_HASH_OUT_ELTS,
+            >>::degree(&gate),
+            5
+        );
 
-        let gate = <CosetInterpolationGate<Goldilocks, 2>>::with_max_degree(3, 7);
+        let gate = <CosetInterpolationGate<Goldilocks, GOLDILOCKS_EXTENSION_FIELD_DEGREE>>::with_max_degree(3, 7);
         assert_eq!(gate.num_intermediates(), 1);
-        assert_eq!(<CosetInterpolationGate<Goldilocks, 2> as Gate<Goldilocks, 2, NUM_HASH_OUT_ELTS>>::degree(&gate), 5);
+        assert_eq!(
+            <CosetInterpolationGate<Goldilocks, GOLDILOCKS_EXTENSION_FIELD_DEGREE> as Gate<
+                Goldilocks,
+                GOLDILOCKS_EXTENSION_FIELD_DEGREE,
+                NUM_HASH_OUT_ELTS,
+            >>::degree(&gate),
+            5
+        );
 
-        let gate = <CosetInterpolationGate<Goldilocks, 2>>::with_max_degree(4, 3);
+        let gate = <CosetInterpolationGate<Goldilocks, GOLDILOCKS_EXTENSION_FIELD_DEGREE>>::with_max_degree(4, 3);
         assert_eq!(gate.num_intermediates(), 7);
-        assert_eq!(<CosetInterpolationGate<Goldilocks, 2> as Gate<Goldilocks, 2, NUM_HASH_OUT_ELTS>>::degree(&gate), 3);
+        assert_eq!(
+            <CosetInterpolationGate<Goldilocks, GOLDILOCKS_EXTENSION_FIELD_DEGREE> as Gate<
+                Goldilocks,
+                GOLDILOCKS_EXTENSION_FIELD_DEGREE,
+                NUM_HASH_OUT_ELTS,
+            >>::degree(&gate),
+            3
+        );
 
-        let gate = <CosetInterpolationGate<Goldilocks, 2>>::with_max_degree(4, 6);
+        let gate = <CosetInterpolationGate<Goldilocks, GOLDILOCKS_EXTENSION_FIELD_DEGREE>>::with_max_degree(4, 6);
         assert_eq!(gate.num_intermediates(), 2);
-        assert_eq!(<CosetInterpolationGate<Goldilocks, 2> as Gate<Goldilocks, 2, NUM_HASH_OUT_ELTS>>::degree(&gate), 6);
+        assert_eq!(
+            <CosetInterpolationGate<Goldilocks, GOLDILOCKS_EXTENSION_FIELD_DEGREE> as Gate<
+                Goldilocks,
+                GOLDILOCKS_EXTENSION_FIELD_DEGREE,
+                NUM_HASH_OUT_ELTS,
+            >>::degree(&gate),
+            6
+        );
 
-        let gate = <CosetInterpolationGate<Goldilocks, 2>>::with_max_degree(4, 8);
+        let gate = <CosetInterpolationGate<Goldilocks, GOLDILOCKS_EXTENSION_FIELD_DEGREE>>::with_max_degree(4, 8);
         assert_eq!(gate.num_intermediates(), 2);
-        assert_eq!(<CosetInterpolationGate<Goldilocks, 2> as Gate<Goldilocks, 2, NUM_HASH_OUT_ELTS>>::degree(&gate), 6);
+        assert_eq!(
+            <CosetInterpolationGate<Goldilocks, GOLDILOCKS_EXTENSION_FIELD_DEGREE> as Gate<
+                Goldilocks,
+                GOLDILOCKS_EXTENSION_FIELD_DEGREE,
+                NUM_HASH_OUT_ELTS,
+            >>::degree(&gate),
+            6
+        );
 
-        let gate = <CosetInterpolationGate<Goldilocks, 2>>::with_max_degree(4, 9);
+        let gate = <CosetInterpolationGate<Goldilocks, GOLDILOCKS_EXTENSION_FIELD_DEGREE>>::with_max_degree(4, 9);
         assert_eq!(gate.num_intermediates(), 1);
-        assert_eq!(<CosetInterpolationGate<Goldilocks, 2> as Gate<Goldilocks, 2, NUM_HASH_OUT_ELTS>>::degree(&gate), 9);
+        assert_eq!(
+            <CosetInterpolationGate<Goldilocks, GOLDILOCKS_EXTENSION_FIELD_DEGREE> as Gate<
+                Goldilocks,
+                GOLDILOCKS_EXTENSION_FIELD_DEGREE,
+                NUM_HASH_OUT_ELTS,
+            >>::degree(&gate),
+            9
+        );
     }
 
     /*
     TODO Update tests with actual values for D=2
     #[test]
     fn wire_indices_degree2() {
-        let gate = CosetInterpolationGate::<Goldilocks, 2> {
+        let gate = CosetInterpolationGate::<Goldilocks, GOLDILOCKS_EXTENSION_FIELD_DEGREE> {
             subgroup_bits: 2,
             degree: 2,
             barycentric_weights: barycentric_weights(
@@ -800,7 +871,7 @@ mod tests {
 
     #[test]
     fn wire_indices_degree_3() {
-        let gate = CosetInterpolationGate::<Goldilocks, 2> {
+        let gate = CosetInterpolationGate::<Goldilocks, GOLDILOCKS_EXTENSION_FIELD_DEGREE> {
             subgroup_bits: 2,
             degree: 3,
             barycentric_weights: barycentric_weights(
@@ -829,7 +900,7 @@ mod tests {
 
     #[test]
     fn wire_indices_degree_n() {
-        let gate = CosetInterpolationGate::<Goldilocks, 2> {
+        let gate = CosetInterpolationGate::<Goldilocks, GOLDILOCKS_EXTENSION_FIELD_DEGREE> {
             subgroup_bits: 2,
             degree: 4,
             barycentric_weights: barycentric_weights(
@@ -856,12 +927,17 @@ mod tests {
     */
     #[test]
     fn low_degree() {
-        test_low_degree::<Goldilocks, _, 2, 4>(CosetInterpolationGate::new(2));
+        test_low_degree::<
+            Goldilocks,
+            _,
+            GOLDILOCKS_EXTENSION_FIELD_DEGREE,
+            GOLDILOCKS_NUM_HASH_OUT_ELTS,
+        >(CosetInterpolationGate::new(2));
     }
 
     #[test]
     fn eval_fns() -> Result<()> {
-        const D: usize = 2;
+        const D: usize = GOLDILOCKS_EXTENSION_FIELD_DEGREE;
         type C = PoseidonGoldilocksConfig;
         const NUM_HASH_OUT_ELTS: usize = GOLDILOCKS_NUM_HASH_OUT_ELTS;
         type F = <C as GenericConfig<D, NUM_HASH_OUT_ELTS>>::F;
@@ -875,7 +951,7 @@ mod tests {
 
     #[test]
     fn test_gate_constraint() {
-        const D: usize = 2;
+        const D: usize = GOLDILOCKS_EXTENSION_FIELD_DEGREE;
         type C = PoseidonGoldilocksConfig;
         const NUM_HASH_OUT_ELTS: usize = GOLDILOCKS_NUM_HASH_OUT_ELTS;
         type F = <C as GenericConfig<D, NUM_HASH_OUT_ELTS>>::F;
@@ -918,7 +994,12 @@ mod tests {
         let values = PolynomialValues::new(core::iter::repeat_with(FF::rand).take(4).collect());
         let eval_point = FF::rand();
         let gate = CosetInterpolationGate::<F, D>::with_max_degree(2, 3);
-        let vars: EvaluationVars<'_, Goldilocks, 2, 4> = EvaluationVars {
+        let vars: EvaluationVars<
+            '_,
+            Goldilocks,
+            GOLDILOCKS_EXTENSION_FIELD_DEGREE,
+            GOLDILOCKS_NUM_HASH_OUT_ELTS,
+        > = EvaluationVars {
             local_constants: &[],
             local_wires: &get_wires(shift, values, eval_point),
             public_inputs_hash: &HashOut::rand(),
@@ -933,16 +1014,58 @@ mod tests {
     #[test]
     fn test_num_wires_constraints() {
         const NUM_HASH_OUT_ELTS: usize = GOLDILOCKS_NUM_HASH_OUT_ELTS;
-        let gate = <CosetInterpolationGate<Goldilocks, 2>>::with_max_degree(4, 8);
-        assert_eq!(<CosetInterpolationGate<Goldilocks, 2> as Gate<Goldilocks, 2, NUM_HASH_OUT_ELTS>>::num_wires(&gate), 47);
-        assert_eq!(<CosetInterpolationGate<Goldilocks, 2> as Gate<Goldilocks, 2, NUM_HASH_OUT_ELTS>>::num_constraints(&gate), 12);
+        let gate = <CosetInterpolationGate<Goldilocks, GOLDILOCKS_EXTENSION_FIELD_DEGREE>>::with_max_degree(4, 8);
+        assert_eq!(
+            <CosetInterpolationGate<Goldilocks, GOLDILOCKS_EXTENSION_FIELD_DEGREE> as Gate<
+                Goldilocks,
+                GOLDILOCKS_EXTENSION_FIELD_DEGREE,
+                NUM_HASH_OUT_ELTS,
+            >>::num_wires(&gate),
+            47
+        );
+        assert_eq!(
+            <CosetInterpolationGate<Goldilocks, GOLDILOCKS_EXTENSION_FIELD_DEGREE> as Gate<
+                Goldilocks,
+                GOLDILOCKS_EXTENSION_FIELD_DEGREE,
+                NUM_HASH_OUT_ELTS,
+            >>::num_constraints(&gate),
+            12
+        );
 
-        let gate = <CosetInterpolationGate<Goldilocks, 2>>::with_max_degree(3, 8);
-        assert_eq!(<CosetInterpolationGate<Goldilocks, 2> as Gate<Goldilocks, 2, NUM_HASH_OUT_ELTS>>::num_wires(&gate), 23);
-        assert_eq!(<CosetInterpolationGate<Goldilocks, 2> as Gate<Goldilocks, 2, NUM_HASH_OUT_ELTS>>::num_constraints(&gate), 4);
+        let gate = <CosetInterpolationGate<Goldilocks, GOLDILOCKS_EXTENSION_FIELD_DEGREE>>::with_max_degree(3, 8);
+        assert_eq!(
+            <CosetInterpolationGate<Goldilocks, GOLDILOCKS_EXTENSION_FIELD_DEGREE> as Gate<
+                Goldilocks,
+                GOLDILOCKS_EXTENSION_FIELD_DEGREE,
+                NUM_HASH_OUT_ELTS,
+            >>::num_wires(&gate),
+            23
+        );
+        assert_eq!(
+            <CosetInterpolationGate<Goldilocks, GOLDILOCKS_EXTENSION_FIELD_DEGREE> as Gate<
+                Goldilocks,
+                GOLDILOCKS_EXTENSION_FIELD_DEGREE,
+                NUM_HASH_OUT_ELTS,
+            >>::num_constraints(&gate),
+            4
+        );
 
-        let gate = <CosetInterpolationGate<Goldilocks, 2>>::with_max_degree(4, 16);
-        assert_eq!(<CosetInterpolationGate<Goldilocks, 2> as Gate<Goldilocks, 2, NUM_HASH_OUT_ELTS>>::num_wires(&gate), 39);
-        assert_eq!(<CosetInterpolationGate<Goldilocks, 2> as Gate<Goldilocks, 2, NUM_HASH_OUT_ELTS>>::num_constraints(&gate), 4);
+        let gate = <CosetInterpolationGate<Goldilocks, GOLDILOCKS_EXTENSION_FIELD_DEGREE>>::with_max_degree(4, 16);
+        assert_eq!(
+            <CosetInterpolationGate<Goldilocks, GOLDILOCKS_EXTENSION_FIELD_DEGREE> as Gate<
+                Goldilocks,
+                GOLDILOCKS_EXTENSION_FIELD_DEGREE,
+                NUM_HASH_OUT_ELTS,
+            >>::num_wires(&gate),
+            39
+        );
+        assert_eq!(
+            <CosetInterpolationGate<Goldilocks, GOLDILOCKS_EXTENSION_FIELD_DEGREE> as Gate<
+                Goldilocks,
+                GOLDILOCKS_EXTENSION_FIELD_DEGREE,
+                NUM_HASH_OUT_ELTS,
+            >>::num_constraints(&gate),
+            4
+        );
     }
 }

--- a/plonky2/src/gates/exponentiation.rs
+++ b/plonky2/src/gates/exponentiation.rs
@@ -342,13 +342,14 @@ mod tests {
     use anyhow::Result;
     use p3_field::Field;
     use p3_goldilocks::Goldilocks;
+    use plonky2_field::{GOLDILOCKS_EXTENSION_FIELD_DEGREE, GOLDILOCKS_NUM_HASH_OUT_ELTS};
     use rand::rngs::OsRng;
     use rand::Rng;
 
     use super::*;
     use crate::field::types::Sample;
     use crate::gates::gate_testing::{test_eval_fns, test_low_degree};
-    use crate::hash::hash_types::{HashOut, GOLDILOCKS_NUM_HASH_OUT_ELTS};
+    use crate::hash::hash_types::HashOut;
     use crate::plonk::config::{GenericConfig, PoseidonGoldilocksConfig};
     use crate::util::log2_ceil;
 
@@ -356,7 +357,7 @@ mod tests {
 
     #[test]
     fn wire_indices() {
-        let gate = ExponentiationGate::<Goldilocks, 2> {
+        let gate = ExponentiationGate::<Goldilocks, GOLDILOCKS_EXTENSION_FIELD_DEGREE> {
             num_power_bits: 5,
             _phantom: PhantomData,
         };
@@ -377,12 +378,17 @@ mod tests {
             ..CircuitConfig::standard_recursion_config_gl()
         };
 
-        test_low_degree::<Goldilocks, _, 2, 4>(ExponentiationGate::new_from_config(&config));
+        test_low_degree::<
+            Goldilocks,
+            _,
+            GOLDILOCKS_EXTENSION_FIELD_DEGREE,
+            GOLDILOCKS_NUM_HASH_OUT_ELTS,
+        >(ExponentiationGate::new_from_config(&config));
     }
 
     #[test]
     fn eval_fns() -> Result<()> {
-        const D: usize = 2;
+        const D: usize = GOLDILOCKS_EXTENSION_FIELD_DEGREE;
         type C = PoseidonGoldilocksConfig;
         const NUM_HASH_OUT_ELTS: usize = GOLDILOCKS_NUM_HASH_OUT_ELTS;
         type F = <C as GenericConfig<D, NUM_HASH_OUT_ELTS>>::F;
@@ -393,7 +399,7 @@ mod tests {
 
     #[test]
     fn test_gate_constraint() {
-        const D: usize = 2;
+        const D: usize = GOLDILOCKS_EXTENSION_FIELD_DEGREE;
         type C = PoseidonGoldilocksConfig;
         const NUM_HASH_OUT_ELTS: usize = GOLDILOCKS_NUM_HASH_OUT_ELTS;
         type F = <C as GenericConfig<D, NUM_HASH_OUT_ELTS>>::F;
@@ -445,7 +451,12 @@ mod tests {
             _phantom: PhantomData,
         };
 
-        let vars: EvaluationVars<'_, Goldilocks, 2, 4> = EvaluationVars {
+        let vars: EvaluationVars<
+            '_,
+            Goldilocks,
+            GOLDILOCKS_EXTENSION_FIELD_DEGREE,
+            GOLDILOCKS_NUM_HASH_OUT_ELTS,
+        > = EvaluationVars {
             local_constants: &[],
             local_wires: &get_wires(base, power as u64),
             public_inputs_hash: &HashOut::rand(),

--- a/plonky2/src/gates/multiplication_extension.rs
+++ b/plonky2/src/gates/multiplication_extension.rs
@@ -241,22 +241,27 @@ impl<F: RichField + HasExtension<D>, const D: usize, const NUM_HASH_OUT_ELTS: us
 mod tests {
     use anyhow::Result;
     use p3_goldilocks::Goldilocks;
+    use plonky2_field::{GOLDILOCKS_EXTENSION_FIELD_DEGREE, GOLDILOCKS_NUM_HASH_OUT_ELTS};
 
     use super::*;
     use crate::gates::gate_testing::{test_eval_fns, test_low_degree};
-    use crate::hash::hash_types::GOLDILOCKS_NUM_HASH_OUT_ELTS;
     use crate::plonk::config::{GenericConfig, PoseidonGoldilocksConfig};
 
     #[test]
     fn low_degree() {
         let gate =
             MulExtensionGate::new_from_config(&CircuitConfig::standard_recursion_config_gl());
-        test_low_degree::<Goldilocks, _, 2, 4>(gate);
+        test_low_degree::<
+            Goldilocks,
+            _,
+            GOLDILOCKS_EXTENSION_FIELD_DEGREE,
+            GOLDILOCKS_NUM_HASH_OUT_ELTS,
+        >(gate);
     }
 
     #[test]
     fn eval_fns() -> Result<()> {
-        const D: usize = 2;
+        const D: usize = GOLDILOCKS_EXTENSION_FIELD_DEGREE;
         type C = PoseidonGoldilocksConfig;
         const NUM_HASH_OUT_ELTS: usize = GOLDILOCKS_NUM_HASH_OUT_ELTS;
         type F = <C as GenericConfig<D, NUM_HASH_OUT_ELTS>>::F;

--- a/plonky2/src/gates/noop.rs
+++ b/plonky2/src/gates/noop.rs
@@ -85,20 +85,25 @@ impl<F: RichField + HasExtension<D>, const D: usize, const NUM_HASH_OUT_ELTS: us
 #[cfg(test)]
 mod tests {
     use p3_goldilocks::Goldilocks;
+    use plonky2_field::{GOLDILOCKS_EXTENSION_FIELD_DEGREE, GOLDILOCKS_NUM_HASH_OUT_ELTS};
 
     use crate::gates::gate_testing::{test_eval_fns, test_low_degree};
     use crate::gates::noop::NoopGate;
-    use crate::hash::hash_types::GOLDILOCKS_NUM_HASH_OUT_ELTS;
     use crate::plonk::config::{GenericConfig, PoseidonGoldilocksConfig};
 
     #[test]
     fn low_degree() {
-        test_low_degree::<Goldilocks, _, 2, 4>(NoopGate)
+        test_low_degree::<
+            Goldilocks,
+            _,
+            GOLDILOCKS_EXTENSION_FIELD_DEGREE,
+            GOLDILOCKS_NUM_HASH_OUT_ELTS,
+        >(NoopGate)
     }
 
     #[test]
     fn eval_fns() -> anyhow::Result<()> {
-        const D: usize = 2;
+        const D: usize = GOLDILOCKS_EXTENSION_FIELD_DEGREE;
         type C = PoseidonGoldilocksConfig;
         const NUM_HASH_OUT_ELTS: usize = GOLDILOCKS_NUM_HASH_OUT_ELTS;
         type F = <C as GenericConfig<D, NUM_HASH_OUT_ELTS>>::F;

--- a/plonky2/src/gates/poseidon2_babybear.rs
+++ b/plonky2/src/gates/poseidon2_babybear.rs
@@ -917,10 +917,10 @@ mod tests {
     use anyhow::Result;
     use p3_baby_bear::BabyBear;
     use plonky2_field::types::Sample;
+    use plonky2_field::{BABYBEAR_EXTENSION_FIELD_DEGREE, BABYBEAR_NUM_HASH_OUT_ELTS};
 
     use super::*;
     use crate::gates::gate_testing::{test_eval_fns, test_low_degree};
-    use crate::hash::hash_types::BABYBEAR_NUM_HASH_OUT_ELTS;
     use crate::hash::poseidon2_babybear::Permuter31;
     use crate::iop::generator::generate_partial_witness;
     use crate::iop::witness::PartialWitness;
@@ -930,7 +930,7 @@ mod tests {
     #[test]
     fn wire_indices() {
         // type F = BabyBear;
-        // const D: usize = 4;
+        // const D: usize = BABYBEAR_EXTENSION_FIELD_DEGREE;
         // type Gate = Poseidon2BabyBearGate<F, D>;
 
         // assert_eq!(Gate::wire_input(0), 0);
@@ -952,7 +952,7 @@ mod tests {
 
     #[test]
     fn generated_output() {
-        const D: usize = 4;
+        const D: usize = BABYBEAR_EXTENSION_FIELD_DEGREE;
         type C = Poseidon2BabyBearConfig;
         const NUM_HASH_OUT_ELTS: usize = BABYBEAR_NUM_HASH_OUT_ELTS;
         type F = <C as GenericConfig<D, NUM_HASH_OUT_ELTS>>::F;
@@ -1009,7 +1009,7 @@ mod tests {
 
     #[test]
     fn eval_fns() -> Result<()> {
-        const D: usize = 4;
+        const D: usize = BABYBEAR_EXTENSION_FIELD_DEGREE;
         type C = Poseidon2BabyBearConfig;
         const NUM_HASH_OUT_ELTS: usize = BABYBEAR_NUM_HASH_OUT_ELTS;
         type F = <C as GenericConfig<D, NUM_HASH_OUT_ELTS>>::F;
@@ -1036,7 +1036,7 @@ mod tests {
 
     #[test]
     fn test_permute_internal_circuit() {
-        const D: usize = 4;
+        const D: usize = BABYBEAR_EXTENSION_FIELD_DEGREE;
         const NUM_HASH_OUT_ELTS: usize = BABYBEAR_NUM_HASH_OUT_ELTS;
         type F = BabyBear;
         type EF = <F as HasExtension<D>>::Extension;
@@ -1060,7 +1060,7 @@ mod tests {
 
     #[test]
     fn test_permute_external_circuit() {
-        const D: usize = 4;
+        const D: usize = BABYBEAR_EXTENSION_FIELD_DEGREE;
         const NUM_HASH_OUT_ELTS: usize = BABYBEAR_NUM_HASH_OUT_ELTS;
         type F = BabyBear;
         type EF = <F as HasExtension<D>>::Extension;

--- a/plonky2/src/gates/poseidon2_internal_permutation.rs
+++ b/plonky2/src/gates/poseidon2_internal_permutation.rs
@@ -295,14 +295,15 @@ impl<F: RichField + HasExtension<D>, const D: usize, const NUM_HASH_OUT_ELTS: us
 
 #[cfg(test)]
 mod tests {
+    use plonky2_field::{BABYBEAR_EXTENSION_FIELD_DEGREE, BABYBEAR_NUM_HASH_OUT_ELTS};
+
     use crate::gates::gate_testing::{test_eval_fns, test_low_degree};
     use crate::gates::poseidon2_internal_permutation::Poseidon2InternalPermutationGate;
-    use crate::hash::hash_types::BABYBEAR_NUM_HASH_OUT_ELTS;
     use crate::plonk::config::{GenericConfig, Poseidon2BabyBearConfig};
 
     #[test]
     fn low_degree() {
-        const D: usize = 4;
+        const D: usize = BABYBEAR_EXTENSION_FIELD_DEGREE;
         type C = Poseidon2BabyBearConfig;
         const NUM_HASH_OUT_ELTS: usize = BABYBEAR_NUM_HASH_OUT_ELTS;
         type F = <C as GenericConfig<D, NUM_HASH_OUT_ELTS>>::F;
@@ -312,7 +313,7 @@ mod tests {
 
     #[test]
     fn eval_fns() -> anyhow::Result<()> {
-        const D: usize = 4;
+        const D: usize = BABYBEAR_EXTENSION_FIELD_DEGREE;
         type C = Poseidon2BabyBearConfig;
         const NUM_HASH_OUT_ELTS: usize = BABYBEAR_NUM_HASH_OUT_ELTS;
         type F = <C as GenericConfig<D, NUM_HASH_OUT_ELTS>>::F;

--- a/plonky2/src/gates/poseidon2_risc0_babybear.rs
+++ b/plonky2/src/gates/poseidon2_risc0_babybear.rs
@@ -819,11 +819,11 @@ where
 mod tests {
     use anyhow::Result;
     use p3_baby_bear::BabyBear;
+    use plonky2_field::{BABYBEAR_EXTENSION_FIELD_DEGREE, BABYBEAR_NUM_HASH_OUT_ELTS};
 
     use super::*;
     use crate::field::types::Sample;
     use crate::gates::gate_testing::{test_eval_fns, test_low_degree};
-    use crate::hash::hash_types::BABYBEAR_NUM_HASH_OUT_ELTS;
     use crate::hash::poseidon2_risc0_babybear::Permuter31R0;
     use crate::iop::generator::generate_partial_witness;
     use crate::iop::witness::PartialWitness;
@@ -833,7 +833,7 @@ mod tests {
     #[test]
     fn wire_indices() {
         // type F = BabyBear;
-        // const D: usize = 4;
+        // const D: usize = BABYBEAR_EXTENSION_FIELD_DEGREE;
         // type Gate = Poseidon2R0BabyBearGate<F, D>;
 
         // assert_eq!(Gate::wire_input(0), 0);
@@ -855,7 +855,7 @@ mod tests {
 
     #[test]
     fn generated_output() {
-        const D: usize = 4;
+        const D: usize = BABYBEAR_EXTENSION_FIELD_DEGREE;
         type C = Poseidon2BabyBearConfig;
         const NUM_HASH_OUT_ELTS: usize = BABYBEAR_NUM_HASH_OUT_ELTS;
         type F = <C as GenericConfig<D, NUM_HASH_OUT_ELTS>>::F;
@@ -911,7 +911,7 @@ mod tests {
 
     #[test]
     fn eval_fns() -> Result<()> {
-        const D: usize = 4;
+        const D: usize = BABYBEAR_EXTENSION_FIELD_DEGREE;
         type C = Poseidon2BabyBearConfig;
         const NUM_HASH_OUT_ELTS: usize = BABYBEAR_NUM_HASH_OUT_ELTS;
         type F = <C as GenericConfig<D, NUM_HASH_OUT_ELTS>>::F;
@@ -921,7 +921,7 @@ mod tests {
 
     #[test]
     fn test_permute_internal_circuit() {
-        const D: usize = 4;
+        const D: usize = BABYBEAR_EXTENSION_FIELD_DEGREE;
         const NUM_HASH_OUT_ELTS: usize = BABYBEAR_NUM_HASH_OUT_ELTS;
         type F = BabyBear;
         type EF = <F as HasExtension<D>>::Extension;
@@ -945,7 +945,7 @@ mod tests {
 
     #[test]
     fn test_permute_external_circuit() {
-        const D: usize = 4;
+        const D: usize = BABYBEAR_EXTENSION_FIELD_DEGREE;
         const NUM_HASH_OUT_ELTS: usize = BABYBEAR_NUM_HASH_OUT_ELTS;
         type F = BabyBear;
         type EF = <F as HasExtension<D>>::Extension;

--- a/plonky2/src/gates/poseidon_goldilocks.rs
+++ b/plonky2/src/gates/poseidon_goldilocks.rs
@@ -560,10 +560,10 @@ impl<F: RichField + HasExtension<D>, const D: usize, const NUM_HASH_OUT_ELTS: us
 mod tests {
     use anyhow::Result;
     use p3_goldilocks::Goldilocks;
+    use plonky2_field::{GOLDILOCKS_EXTENSION_FIELD_DEGREE, GOLDILOCKS_NUM_HASH_OUT_ELTS};
 
     use super::*;
     use crate::gates::gate_testing::{test_eval_fns, test_low_degree};
-    use crate::hash::hash_types::GOLDILOCKS_NUM_HASH_OUT_ELTS;
     use crate::iop::generator::generate_partial_witness;
     use crate::iop::witness::PartialWitness;
     use crate::plonk::circuit_data::CircuitConfig;
@@ -572,7 +572,7 @@ mod tests {
     #[test]
     fn wire_indices() {
         type F = Goldilocks;
-        const D: usize = 2;
+        const D: usize = GOLDILOCKS_EXTENSION_FIELD_DEGREE;
         type Gate = PoseidonGate<F, D>;
 
         assert_eq!(Gate::wire_input(0), 0);
@@ -594,7 +594,7 @@ mod tests {
 
     #[test]
     fn generated_output() {
-        const D: usize = 2;
+        const D: usize = GOLDILOCKS_EXTENSION_FIELD_DEGREE;
         type C = PoseidonGoldilocksConfig;
         const NUM_HASH_OUT_ELTS: usize = GOLDILOCKS_NUM_HASH_OUT_ELTS;
         type F = <C as GenericConfig<D, NUM_HASH_OUT_ELTS>>::F;
@@ -647,17 +647,19 @@ mod tests {
     #[test]
     fn low_degree() {
         type F = Goldilocks;
-        let gate = PoseidonGate::<F, 2>::new();
-        test_low_degree::<F, PoseidonGate<F, 2>, 2, 4>(gate)
+        const D: usize = GOLDILOCKS_EXTENSION_FIELD_DEGREE;
+        const NUM_HASH_OUT_ELTS: usize = GOLDILOCKS_NUM_HASH_OUT_ELTS;
+        let gate = PoseidonGate::<F, D>::new();
+        test_low_degree::<F, PoseidonGate<F, D>, D, NUM_HASH_OUT_ELTS>(gate)
     }
 
     #[test]
     fn eval_fns() -> Result<()> {
-        const D: usize = 2;
+        const D: usize = GOLDILOCKS_EXTENSION_FIELD_DEGREE;
         type C = PoseidonGoldilocksConfig;
         const NUM_HASH_OUT_ELTS: usize = GOLDILOCKS_NUM_HASH_OUT_ELTS;
         type F = <C as GenericConfig<D, NUM_HASH_OUT_ELTS>>::F;
-        let gate = PoseidonGate::<F, 2>::new();
+        let gate = PoseidonGate::<F, D>::new();
         test_eval_fns::<F, C, _, D, NUM_HASH_OUT_ELTS>(gate)
     }
 }

--- a/plonky2/src/gates/poseidon_goldilocks_mds.rs
+++ b/plonky2/src/gates/poseidon_goldilocks_mds.rs
@@ -304,14 +304,15 @@ impl<F: RichField + HasExtension<D>, const D: usize, const NUM_HASH_OUT_ELTS: us
 
 #[cfg(test)]
 mod tests {
+    use plonky2_field::{GOLDILOCKS_EXTENSION_FIELD_DEGREE, GOLDILOCKS_NUM_HASH_OUT_ELTS};
+
     use crate::gates::gate_testing::{test_eval_fns, test_low_degree};
     use crate::gates::poseidon_goldilocks_mds::PoseidonMdsGate;
-    use crate::hash::hash_types::GOLDILOCKS_NUM_HASH_OUT_ELTS;
     use crate::plonk::config::{GenericConfig, PoseidonGoldilocksConfig};
 
     #[test]
     fn low_degree() {
-        const D: usize = 2;
+        const D: usize = GOLDILOCKS_EXTENSION_FIELD_DEGREE;
         type C = PoseidonGoldilocksConfig;
         const NUM_HASH_OUT_ELTS: usize = GOLDILOCKS_NUM_HASH_OUT_ELTS;
         type F = <C as GenericConfig<D, NUM_HASH_OUT_ELTS>>::F;
@@ -321,7 +322,7 @@ mod tests {
 
     #[test]
     fn eval_fns() -> anyhow::Result<()> {
-        const D: usize = 2;
+        const D: usize = GOLDILOCKS_EXTENSION_FIELD_DEGREE;
         type C = PoseidonGoldilocksConfig;
         const NUM_HASH_OUT_ELTS: usize = GOLDILOCKS_NUM_HASH_OUT_ELTS;
         type F = <C as GenericConfig<D, NUM_HASH_OUT_ELTS>>::F;

--- a/plonky2/src/gates/public_input.rs
+++ b/plonky2/src/gates/public_input.rs
@@ -131,20 +131,22 @@ impl<F: RichField + HasExtension<D>, const D: usize, const NUM_HASH_OUT_ELTS: us
 #[cfg(test)]
 mod tests {
     use p3_baby_bear::BabyBear;
+    use plonky2_field::{BABYBEAR_EXTENSION_FIELD_DEGREE, BABYBEAR_NUM_HASH_OUT_ELTS};
 
     use crate::gates::gate_testing::{test_eval_fns, test_low_degree};
     use crate::gates::public_input::PublicInputGate;
-    use crate::hash::hash_types::BABYBEAR_NUM_HASH_OUT_ELTS;
     use crate::plonk::config::{GenericConfig, Poseidon2BabyBearConfig};
 
     #[test]
     fn low_degree() {
-        test_low_degree::<BabyBear, _, 4, 8>(PublicInputGate)
+        test_low_degree::<BabyBear, _, BABYBEAR_EXTENSION_FIELD_DEGREE, BABYBEAR_NUM_HASH_OUT_ELTS>(
+            PublicInputGate,
+        )
     }
 
     #[test]
     fn eval_fns() -> anyhow::Result<()> {
-        const D: usize = 4;
+        const D: usize = BABYBEAR_EXTENSION_FIELD_DEGREE;
         type C = Poseidon2BabyBearConfig;
         const NUM_HASH_OUT_ELTS: usize = BABYBEAR_NUM_HASH_OUT_ELTS;
         type F = <C as GenericConfig<D, NUM_HASH_OUT_ELTS>>::F;

--- a/plonky2/src/gates/random_access.rs
+++ b/plonky2/src/gates/random_access.rs
@@ -443,23 +443,29 @@ mod tests {
     use anyhow::Result;
     use p3_field::Field;
     use p3_goldilocks::Goldilocks;
+    use plonky2_field::{GOLDILOCKS_EXTENSION_FIELD_DEGREE, GOLDILOCKS_NUM_HASH_OUT_ELTS};
     use rand::rngs::OsRng;
     use rand::Rng;
 
     use super::*;
     use crate::field::types::Sample;
     use crate::gates::gate_testing::{test_eval_fns, test_low_degree};
-    use crate::hash::hash_types::{HashOut, GOLDILOCKS_NUM_HASH_OUT_ELTS};
+    use crate::hash::hash_types::HashOut;
     use crate::plonk::config::{GenericConfig, PoseidonGoldilocksConfig};
 
     #[test]
     fn low_degree() {
-        test_low_degree::<Goldilocks, _, 2, 4>(RandomAccessGate::new(4, 4, 1));
+        test_low_degree::<
+            Goldilocks,
+            _,
+            GOLDILOCKS_EXTENSION_FIELD_DEGREE,
+            GOLDILOCKS_NUM_HASH_OUT_ELTS,
+        >(RandomAccessGate::new(4, 4, 1));
     }
 
     #[test]
     fn eval_fns() -> Result<()> {
-        const D: usize = 2;
+        const D: usize = GOLDILOCKS_EXTENSION_FIELD_DEGREE;
         type C = PoseidonGoldilocksConfig;
         const NUM_HASH_OUT_ELTS: usize = GOLDILOCKS_NUM_HASH_OUT_ELTS;
         type F = <C as GenericConfig<D, NUM_HASH_OUT_ELTS>>::F;
@@ -468,7 +474,7 @@ mod tests {
 
     #[test]
     fn test_gate_constraint() {
-        const D: usize = 2;
+        const D: usize = GOLDILOCKS_EXTENSION_FIELD_DEGREE;
         type C = PoseidonGoldilocksConfig;
         const NUM_HASH_OUT_ELTS: usize = GOLDILOCKS_NUM_HASH_OUT_ELTS;
         type F = <C as GenericConfig<D, NUM_HASH_OUT_ELTS>>::F;
@@ -530,7 +536,12 @@ mod tests {
             .zip(&access_indices)
             .map(|(l, &i)| l[i])
             .collect();
-        let good_vars: EvaluationVars<'_, Goldilocks, 2, 4> = EvaluationVars {
+        let good_vars: EvaluationVars<
+            '_,
+            Goldilocks,
+            GOLDILOCKS_EXTENSION_FIELD_DEGREE,
+            GOLDILOCKS_NUM_HASH_OUT_ELTS,
+        > = EvaluationVars {
             local_constants: &constants.iter().map(|&x| x.into()).collect::<Vec<_>>(),
             local_wires: &get_wires(
                 bits,
@@ -542,7 +553,12 @@ mod tests {
             public_inputs_hash: &HashOut::rand(),
         };
         let bad_claimed_elements = F::rand_vec(4);
-        let bad_vars: EvaluationVars<'_, Goldilocks, 2, 4> = EvaluationVars {
+        let bad_vars: EvaluationVars<
+            '_,
+            Goldilocks,
+            GOLDILOCKS_EXTENSION_FIELD_DEGREE,
+            GOLDILOCKS_NUM_HASH_OUT_ELTS,
+        > = EvaluationVars {
             local_constants: &constants.iter().map(|&x| x.into()).collect::<Vec<_>>(),
             local_wires: &get_wires(
                 bits,

--- a/plonky2/src/gates/reducing.rs
+++ b/plonky2/src/gates/reducing.rs
@@ -282,20 +282,25 @@ impl<F: RichField + HasExtension<D>, const D: usize, const NUM_HASH_OUT_ELTS: us
 mod tests {
     use anyhow::Result;
     use p3_goldilocks::Goldilocks;
+    use plonky2_field::{GOLDILOCKS_EXTENSION_FIELD_DEGREE, GOLDILOCKS_NUM_HASH_OUT_ELTS};
 
     use crate::gates::gate_testing::{test_eval_fns, test_low_degree};
     use crate::gates::reducing::ReducingGate;
-    use crate::hash::hash_types::GOLDILOCKS_NUM_HASH_OUT_ELTS;
     use crate::plonk::config::{GenericConfig, PoseidonGoldilocksConfig};
 
     #[test]
     fn low_degree() {
-        test_low_degree::<Goldilocks, _, 2, 4>(ReducingGate::new(22));
+        test_low_degree::<
+            Goldilocks,
+            _,
+            GOLDILOCKS_EXTENSION_FIELD_DEGREE,
+            GOLDILOCKS_NUM_HASH_OUT_ELTS,
+        >(ReducingGate::new(22));
     }
 
     #[test]
     fn eval_fns() -> Result<()> {
-        const D: usize = 2;
+        const D: usize = GOLDILOCKS_EXTENSION_FIELD_DEGREE;
         type C = PoseidonGoldilocksConfig;
         const NUM_HASH_OUT_ELTS: usize = GOLDILOCKS_NUM_HASH_OUT_ELTS;
         type F = <C as GenericConfig<D, NUM_HASH_OUT_ELTS>>::F;

--- a/plonky2/src/gates/reducing_extension.rs
+++ b/plonky2/src/gates/reducing_extension.rs
@@ -281,20 +281,25 @@ impl<F: RichField + HasExtension<D>, const D: usize, const NUM_HASH_OUT_ELTS: us
 mod tests {
     use anyhow::Result;
     use p3_goldilocks::Goldilocks;
+    use plonky2_field::{GOLDILOCKS_EXTENSION_FIELD_DEGREE, GOLDILOCKS_NUM_HASH_OUT_ELTS};
 
     use crate::gates::gate_testing::{test_eval_fns, test_low_degree};
     use crate::gates::reducing_extension::ReducingExtensionGate;
-    use crate::hash::hash_types::GOLDILOCKS_NUM_HASH_OUT_ELTS;
     use crate::plonk::config::{GenericConfig, PoseidonGoldilocksConfig};
 
     #[test]
     fn low_degree() {
-        test_low_degree::<Goldilocks, _, 2, 4>(ReducingExtensionGate::new(22));
+        test_low_degree::<
+            Goldilocks,
+            _,
+            GOLDILOCKS_EXTENSION_FIELD_DEGREE,
+            GOLDILOCKS_NUM_HASH_OUT_ELTS,
+        >(ReducingExtensionGate::new(22));
     }
 
     #[test]
     fn eval_fns() -> Result<()> {
-        const D: usize = 2;
+        const D: usize = GOLDILOCKS_EXTENSION_FIELD_DEGREE;
         type C = PoseidonGoldilocksConfig;
         const NUM_HASH_OUT_ELTS: usize = GOLDILOCKS_NUM_HASH_OUT_ELTS;
         type F = <C as GenericConfig<D, NUM_HASH_OUT_ELTS>>::F;

--- a/plonky2/src/hash/hash_types.rs
+++ b/plonky2/src/hash/hash_types.rs
@@ -6,6 +6,7 @@ use anyhow::ensure;
 use p3_baby_bear::BabyBear;
 use p3_field::{AbstractField, Field, PrimeField32, PrimeField64, TwoAdicField};
 use p3_goldilocks::Goldilocks;
+use plonky2_field::{BABYBEAR_NUM_HASH_OUT_ELTS, GOLDILOCKS_NUM_HASH_OUT_ELTS};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use static_assertions::const_assert;
 
@@ -25,9 +26,6 @@ pub trait RichField: PrimeField64 + Sample + TwoAdicField {
     fn to_bytes(&self) -> Vec<u8>;
     fn hash_out_elements_from_bytes(bytes: &[u8]) -> Vec<Self>;
 }
-
-pub const GOLDILOCKS_NUM_HASH_OUT_ELTS: usize = 4;
-pub const GOLDILOCKS_EXTENSION_FIELD_DEGREE: usize = 2;
 
 impl RichField for Goldilocks {
     const NUM_HASH_OUT_ELTS: usize = GOLDILOCKS_NUM_HASH_OUT_ELTS;
@@ -62,9 +60,6 @@ const_assert!(
     Goldilocks::ORDER_U64
         == ((1u128 << Goldilocks::EXP0) - (1u128 << Goldilocks::EXP1) + 1u128) as u64
 );
-
-pub const BABYBEAR_NUM_HASH_OUT_ELTS: usize = 8;
-pub const BABYBEAR_EXTENSION_FIELD_DEGREE: usize = 4;
 
 impl RichField for BabyBear {
     const NUM_HASH_OUT_ELTS: usize = BABYBEAR_NUM_HASH_OUT_ELTS;

--- a/plonky2/src/hash/hash_types.rs
+++ b/plonky2/src/hash/hash_types.rs
@@ -27,6 +27,7 @@ pub trait RichField: PrimeField64 + Sample + TwoAdicField {
 }
 
 pub const GOLDILOCKS_NUM_HASH_OUT_ELTS: usize = 4;
+pub const GOLDILOCKS_EXTENSION_FIELD_DEGREE: usize = 2;
 
 impl RichField for Goldilocks {
     const NUM_HASH_OUT_ELTS: usize = GOLDILOCKS_NUM_HASH_OUT_ELTS;
@@ -63,6 +64,7 @@ const_assert!(
 );
 
 pub const BABYBEAR_NUM_HASH_OUT_ELTS: usize = 8;
+pub const BABYBEAR_EXTENSION_FIELD_DEGREE: usize = 4;
 
 impl RichField for BabyBear {
     const NUM_HASH_OUT_ELTS: usize = BABYBEAR_NUM_HASH_OUT_ELTS;

--- a/plonky2/src/hash/merkle_proofs.rs
+++ b/plonky2/src/hash/merkle_proofs.rs
@@ -189,11 +189,11 @@ impl<F: RichField + HasExtension<D>, const D: usize, const NUM_HASH_OUT_ELTS: us
 mod tests {
     use p3_field::{AbstractField, Field};
     use plonky2_field::types::Sample;
+    use plonky2_field::{GOLDILOCKS_EXTENSION_FIELD_DEGREE, GOLDILOCKS_NUM_HASH_OUT_ELTS};
     use rand::rngs::OsRng;
     use rand::Rng;
 
     use super::*;
-    use crate::hash::hash_types::GOLDILOCKS_NUM_HASH_OUT_ELTS;
     use crate::hash::merkle_tree::MerkleTree;
     use crate::iop::witness::{PartialWitness, WitnessWrite};
     use crate::plonk::circuit_data::CircuitConfig;
@@ -206,7 +206,7 @@ mod tests {
 
     #[test]
     fn test_recursive_merkle_proof() -> Result<()> {
-        const D: usize = 2;
+        const D: usize = GOLDILOCKS_EXTENSION_FIELD_DEGREE;
         const NUM_HASH_OUT_ELTS: usize = GOLDILOCKS_NUM_HASH_OUT_ELTS;
         type C = PoseidonGoldilocksConfig;
         type F = <C as GenericConfig<D, NUM_HASH_OUT_ELTS>>::F;

--- a/plonky2/src/hash/merkle_tree.rs
+++ b/plonky2/src/hash/merkle_tree.rs
@@ -226,9 +226,9 @@ impl<F: RichField, H: Hasher<F>> MerkleTree<F, H> {
 mod tests {
     use anyhow::Result;
     use plonky2_field::types::HasExtension;
+    use plonky2_field::{GOLDILOCKS_EXTENSION_FIELD_DEGREE, GOLDILOCKS_NUM_HASH_OUT_ELTS};
 
     use super::*;
-    use crate::hash::hash_types::GOLDILOCKS_NUM_HASH_OUT_ELTS;
     use crate::hash::merkle_proofs::verify_merkle_proof_to_cap;
     use crate::plonk::config::{GenericConfig, PoseidonGoldilocksConfig};
 
@@ -257,7 +257,7 @@ where {
     #[test]
     #[should_panic]
     fn test_cap_height_too_big() {
-        const D: usize = 2;
+        const D: usize = GOLDILOCKS_EXTENSION_FIELD_DEGREE;
         type C = PoseidonGoldilocksConfig;
         const NUM_HASH_OUT_ELTS: usize = GOLDILOCKS_NUM_HASH_OUT_ELTS;
         type F = <C as GenericConfig<D, NUM_HASH_OUT_ELTS>>::F;
@@ -273,7 +273,7 @@ where {
 
     #[test]
     fn test_cap_height_eq_log2_len() -> Result<()> {
-        const D: usize = 2;
+        const D: usize = GOLDILOCKS_EXTENSION_FIELD_DEGREE;
         type C = PoseidonGoldilocksConfig;
         const NUM_HASH_OUT_ELTS: usize = GOLDILOCKS_NUM_HASH_OUT_ELTS;
         type F = <C as GenericConfig<D, NUM_HASH_OUT_ELTS>>::F;
@@ -289,7 +289,7 @@ where {
 
     #[test]
     fn test_merkle_trees() -> Result<()> {
-        const D: usize = 2;
+        const D: usize = GOLDILOCKS_EXTENSION_FIELD_DEGREE;
         type C = PoseidonGoldilocksConfig;
         const NUM_HASH_OUT_ELTS: usize = GOLDILOCKS_NUM_HASH_OUT_ELTS;
         type F = <C as GenericConfig<D, NUM_HASH_OUT_ELTS>>::F;

--- a/plonky2/src/hash/path_compression.rs
+++ b/plonky2/src/hash/path_compression.rs
@@ -114,18 +114,18 @@ pub(crate) fn decompress_merkle_proofs<F: RichField, H: Hasher<F>>(
 
 #[cfg(test)]
 mod tests {
+    use plonky2_field::{GOLDILOCKS_EXTENSION_FIELD_DEGREE, GOLDILOCKS_NUM_HASH_OUT_ELTS};
     use rand::rngs::OsRng;
     use rand::Rng;
 
     use super::*;
     use crate::field::types::Sample;
-    use crate::hash::hash_types::GOLDILOCKS_NUM_HASH_OUT_ELTS;
     use crate::hash::merkle_tree::MerkleTree;
     use crate::plonk::config::{GenericConfig, PoseidonGoldilocksConfig};
 
     #[test]
     fn test_path_compression() {
-        const D: usize = 2;
+        const D: usize = GOLDILOCKS_EXTENSION_FIELD_DEGREE;
         type C = PoseidonGoldilocksConfig;
         const NUM_HASH_OUT_ELTS: usize = GOLDILOCKS_NUM_HASH_OUT_ELTS;
         type F = <C as GenericConfig<D, NUM_HASH_OUT_ELTS>>::F;

--- a/plonky2/src/hash/poseidon2_babybear.rs
+++ b/plonky2/src/hash/poseidon2_babybear.rs
@@ -216,8 +216,8 @@ impl<F: RichField> AlgebraicHasher<F, 8> for Poseidon2BabyBearHash {
 #[cfg(test)]
 mod tests {
     use p3_baby_bear::BabyBear;
+    use plonky2_field::{BABYBEAR_EXTENSION_FIELD_DEGREE, BABYBEAR_NUM_HASH_OUT_ELTS};
 
-    use crate::hash::hash_types::BABYBEAR_NUM_HASH_OUT_ELTS;
     use crate::hash::poseidon2_babybear::Poseidon2BabyBearHash;
     use crate::plonk::circuit_builder::CircuitBuilder;
     use crate::plonk::config::Hasher;
@@ -230,7 +230,7 @@ mod tests {
         use crate::plonk::circuit_data::{CircuitConfig, CircuitData};
         use crate::plonk::config::Poseidon2BabyBearConfig;
         type F = BabyBear;
-        const D: usize = 4;
+        const D: usize = BABYBEAR_EXTENSION_FIELD_DEGREE;
         const NUM_HASH_OUT_ELTS: usize = BABYBEAR_NUM_HASH_OUT_ELTS;
         type H = Poseidon2BabyBearHash;
         type C = Poseidon2BabyBearConfig;

--- a/plonky2/src/hash/poseidon2_risc0_babybear.rs
+++ b/plonky2/src/hash/poseidon2_risc0_babybear.rs
@@ -311,10 +311,10 @@ mod tests {
     use p3_baby_bear::BabyBear;
     use p3_field::AbstractField;
     use p3_symmetric::Permutation;
+    use plonky2_field::{BABYBEAR_EXTENSION_FIELD_DEGREE, BABYBEAR_NUM_HASH_OUT_ELTS};
 
     use super::{poseidon2_r0, Poseidon2R0BabyBearHash, SPONGE_WIDTH};
     use crate::field::types::Sample;
-    use crate::hash::hash_types::BABYBEAR_NUM_HASH_OUT_ELTS;
     use crate::plonk::circuit_builder::CircuitBuilder;
 
     #[test]
@@ -346,7 +346,7 @@ mod tests {
         use crate::plonk::circuit_data::{CircuitConfig, CircuitData};
         use crate::plonk::config::Poseidon2BabyBearConfig;
         type F = BabyBear;
-        const D: usize = 4;
+        const D: usize = BABYBEAR_EXTENSION_FIELD_DEGREE;
         const NUM_HASH_OUT_ELTS: usize = BABYBEAR_NUM_HASH_OUT_ELTS;
         type H = Poseidon2R0BabyBearHash;
         type C = Poseidon2BabyBearConfig;

--- a/plonky2/src/iop/challenger.rs
+++ b/plonky2/src/iop/challenger.rs
@@ -309,8 +309,9 @@ mod tests {
     #[cfg(not(feature = "std"))]
     use alloc::vec::Vec;
 
+    use plonky2_field::{GOLDILOCKS_EXTENSION_FIELD_DEGREE, GOLDILOCKS_NUM_HASH_OUT_ELTS};
+
     use crate::field::types::Sample;
-    use crate::hash::hash_types::GOLDILOCKS_NUM_HASH_OUT_ELTS;
     use crate::iop::challenger::{Challenger, RecursiveChallenger};
     use crate::iop::generator::generate_partial_witness;
     use crate::iop::target::Target;
@@ -321,7 +322,7 @@ mod tests {
 
     #[test]
     fn no_duplicate_challenges() {
-        const D: usize = 2;
+        const D: usize = GOLDILOCKS_EXTENSION_FIELD_DEGREE;
         type C = PoseidonGoldilocksConfig;
         const NUM_HASH_OUT_ELTS: usize = GOLDILOCKS_NUM_HASH_OUT_ELTS;
         type F = <C as GenericConfig<D, NUM_HASH_OUT_ELTS>>::F;
@@ -345,7 +346,7 @@ mod tests {
     /// Tests for consistency between `Challenger` and `RecursiveChallenger`.
     #[test]
     fn test_consistency() {
-        const D: usize = 2;
+        const D: usize = GOLDILOCKS_EXTENSION_FIELD_DEGREE;
         type C = PoseidonGoldilocksConfig;
         const NUM_HASH_OUT_ELTS: usize = GOLDILOCKS_NUM_HASH_OUT_ELTS;
         type F = <C as GenericConfig<D, NUM_HASH_OUT_ELTS>>::F;

--- a/plonky2/src/lib.rs
+++ b/plonky2/src/lib.rs
@@ -3,7 +3,8 @@
 #![deny(rustdoc::broken_intra_doc_links)]
 #![deny(missing_debug_implementations)]
 #![cfg_attr(not(feature = "std"), no_std)]
-
+#![allow(stable_features)]
+#![feature(unsigned_is_multiple_of)]
 #[cfg(not(feature = "std"))]
 pub extern crate alloc;
 

--- a/plonky2/src/lookup_test.rs
+++ b/plonky2/src/lookup_test.rs
@@ -17,7 +17,7 @@ use crate::plonk::config::{GenericConfig, PoseidonGoldilocksConfig};
 use crate::plonk::prover::prove;
 use crate::util::timing::TimingTree;
 
-const D: usize = 2;
+const D: usize = GOLDILOCKS_EXTENSION_FIELD_DEGREE;
 type C = PoseidonGoldilocksConfig;
 type F = <C as GenericConfig<D, NUM_HASH_OUT_ELTS>>::F;
 

--- a/plonky2/src/plonk/circuit_builder.rs
+++ b/plonky2/src/plonk/circuit_builder.rs
@@ -94,7 +94,7 @@ pub struct LookupWire {
 ///
 /// ```rust
 /// use p3_field::AbstractField;
-/// use plonky2::hash::hash_types::GOLDILOCKS_NUM_HASH_OUT_ELTS;
+/// use plonky2_field::{GOLDILOCKS_NUM_HASH_OUT_ELTS, GOLDILOCKS_EXTENSION_FIELD_DEGREE};
 /// use plonky2::plonk::circuit_data::CircuitConfig;
 /// use plonky2::iop::witness::PartialWitness;
 /// use plonky2::plonk::circuit_builder::CircuitBuilder;
@@ -102,7 +102,7 @@ pub struct LookupWire {
 ///
 ///
 /// // Define parameters for this circuit
-/// const D: usize = 2;
+/// const D: usize = GOLDILOCKS_EXTENSION_FIELD_DEGREE;
 /// const NUM_HASH_OUT_ELTS: usize = GOLDILOCKS_NUM_HASH_OUT_ELTS;
 /// type C = PoseidonGoldilocksConfig;
 /// type F = <C as GenericConfig<D, NUM_HASH_OUT_ELTS>>::F;

--- a/plonky2/src/plonk/config.rs
+++ b/plonky2/src/plonk/config.rs
@@ -15,6 +15,10 @@ use p3_field::extension::BinomialExtensionField;
 use p3_field::{ExtensionField, Field, TwoAdicField};
 use p3_goldilocks::Goldilocks;
 use plonky2_field::types::HasExtension;
+use plonky2_field::{
+    BABYBEAR_EXTENSION_FIELD_DEGREE, BABYBEAR_NUM_HASH_OUT_ELTS, GOLDILOCKS_EXTENSION_FIELD_DEGREE,
+    GOLDILOCKS_NUM_HASH_OUT_ELTS,
+};
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 
@@ -179,7 +183,9 @@ pub trait GenericConfig<const D: usize, const NUM_HASH_OUT_ELTS: usize>:
 /// Configuration using Poseidon over the Goldilocks field.
 #[derive(Debug, Copy, Clone, Default, Eq, PartialEq, Serialize)]
 pub struct PoseidonGoldilocksConfig;
-impl GenericConfig<2, 4> for PoseidonGoldilocksConfig {
+impl GenericConfig<GOLDILOCKS_EXTENSION_FIELD_DEGREE, GOLDILOCKS_NUM_HASH_OUT_ELTS>
+    for PoseidonGoldilocksConfig
+{
     type F = Goldilocks;
     type FE = BinomialExtensionField<Self::F, 2>;
     type Hasher = Poseidon64Hash;
@@ -188,7 +194,9 @@ impl GenericConfig<2, 4> for PoseidonGoldilocksConfig {
 
 #[derive(Debug, Copy, Clone, Default, Eq, PartialEq, Serialize)]
 pub struct Poseidon2BabyBearConfig;
-impl GenericConfig<4, 8> for Poseidon2BabyBearConfig {
+impl GenericConfig<BABYBEAR_EXTENSION_FIELD_DEGREE, BABYBEAR_NUM_HASH_OUT_ELTS>
+    for Poseidon2BabyBearConfig
+{
     type F = BabyBear;
     type FE = BinomialExtensionField<Self::F, 4>;
     type Hasher = Poseidon2BabyBearHash;
@@ -198,9 +206,11 @@ impl GenericConfig<4, 8> for Poseidon2BabyBearConfig {
 /// Configuration using truncated Keccak over the Goldilocks field.
 #[derive(Debug, Copy, Clone, Default, Eq, PartialEq)]
 pub struct KeccakGoldilocksConfig;
-impl GenericConfig<2, 4> for KeccakGoldilocksConfig {
+impl GenericConfig<GOLDILOCKS_EXTENSION_FIELD_DEGREE, GOLDILOCKS_NUM_HASH_OUT_ELTS>
+    for KeccakGoldilocksConfig
+{
     type F = Goldilocks;
-    type FE = BinomialExtensionField<Self::F, 2>;
+    type FE = BinomialExtensionField<Self::F, GOLDILOCKS_EXTENSION_FIELD_DEGREE>;
     type Hasher = KeccakHash<25>;
     type InnerHasher = Poseidon64Hash;
 }

--- a/plonky2/src/plonk/proof.rs
+++ b/plonky2/src/plonk/proof.rs
@@ -497,12 +497,12 @@ mod tests {
     use itertools::Itertools;
     use p3_field::AbstractField;
     use plonky2_field::types::Sample;
+    use plonky2_field::{GOLDILOCKS_EXTENSION_FIELD_DEGREE, GOLDILOCKS_NUM_HASH_OUT_ELTS};
 
     use super::*;
     use crate::fri::reduction_strategies::FriReductionStrategy;
     use crate::gates::lookup_table::LookupTable;
     use crate::gates::noop::NoopGate;
-    use crate::hash::hash_types::GOLDILOCKS_NUM_HASH_OUT_ELTS;
     use crate::iop::witness::PartialWitness;
     use crate::plonk::circuit_builder::CircuitBuilder;
     use crate::plonk::circuit_data::CircuitConfig;
@@ -511,7 +511,7 @@ mod tests {
 
     #[test]
     fn test_proof_compression() -> Result<()> {
-        const D: usize = 2;
+        const D: usize = GOLDILOCKS_EXTENSION_FIELD_DEGREE;
         type C = PoseidonGoldilocksConfig;
         const NUM_HASH_OUT_ELTS: usize = GOLDILOCKS_NUM_HASH_OUT_ELTS;
         type F = <C as GenericConfig<D, NUM_HASH_OUT_ELTS>>::F;
@@ -550,7 +550,7 @@ mod tests {
 
     #[test]
     fn test_proof_compression_lookup() -> Result<()> {
-        const D: usize = 2;
+        const D: usize = GOLDILOCKS_EXTENSION_FIELD_DEGREE;
         type C = PoseidonGoldilocksConfig;
         const NUM_HASH_OUT_ELTS: usize = GOLDILOCKS_NUM_HASH_OUT_ELTS;
 
@@ -610,9 +610,9 @@ mod tests {
     mod tests_non_rand {
         use p3_field::AbstractField;
         use plonky2_field::types::tests_non_rand;
+        use plonky2_field::{BABYBEAR_EXTENSION_FIELD_DEGREE, BABYBEAR_NUM_HASH_OUT_ELTS};
 
         use crate::gates::noop::NoopGate;
-        use crate::hash::hash_types::BABYBEAR_NUM_HASH_OUT_ELTS;
         use crate::iop::witness::{PartialWitness, WitnessWrite};
         use crate::plonk::circuit_builder::CircuitBuilder;
         use crate::plonk::circuit_data::CircuitConfig;
@@ -622,7 +622,7 @@ mod tests {
 
         #[test]
         fn test_proof_permutation_argument_div_zero() {
-            const D: usize = 4;
+            const D: usize = BABYBEAR_EXTENSION_FIELD_DEGREE;
             type C = Poseidon2BabyBearConfig;
             const NUM_HASH_OUT_ELTS: usize = BABYBEAR_NUM_HASH_OUT_ELTS;
             type F = <C as GenericConfig<D, NUM_HASH_OUT_ELTS>>::F;

--- a/plonky2/src/recursion/conditional_recursive_verifier.rs
+++ b/plonky2/src/recursion/conditional_recursive_verifier.rs
@@ -349,11 +349,11 @@ mod tests {
     use anyhow::Result;
     use hashbrown::HashMap;
     use p3_field::PrimeField64;
+    use plonky2_field::{GOLDILOCKS_EXTENSION_FIELD_DEGREE, GOLDILOCKS_NUM_HASH_OUT_ELTS};
 
     use super::*;
     use crate::field::types::Sample;
     use crate::gates::noop::NoopGate;
-    use crate::hash::hash_types::GOLDILOCKS_NUM_HASH_OUT_ELTS;
     use crate::iop::witness::{PartialWitness, WitnessWrite};
     use crate::plonk::circuit_data::CircuitConfig;
     use crate::plonk::config::PoseidonGoldilocksConfig;
@@ -362,7 +362,7 @@ mod tests {
     #[test]
     fn test_conditional_recursive_verifier() -> Result<()> {
         init_logger();
-        const D: usize = 2;
+        const D: usize = GOLDILOCKS_EXTENSION_FIELD_DEGREE;
         type C = PoseidonGoldilocksConfig;
         const NUM_HASH_OUT_ELTS: usize = GOLDILOCKS_NUM_HASH_OUT_ELTS;
         type F = <C as GenericConfig<D, NUM_HASH_OUT_ELTS>>::F;

--- a/plonky2/src/recursion/cyclic_recursion.rs
+++ b/plonky2/src/recursion/cyclic_recursion.rs
@@ -225,9 +225,10 @@ mod tests {
     use anyhow::Result;
     use p3_field::{AbstractField, PrimeField64};
     use plonky2_field::types::HasExtension;
+    use plonky2_field::{GOLDILOCKS_EXTENSION_FIELD_DEGREE, GOLDILOCKS_NUM_HASH_OUT_ELTS};
 
     use crate::gates::noop::NoopGate;
-    use crate::hash::hash_types::{HashOutTarget, RichField, GOLDILOCKS_NUM_HASH_OUT_ELTS};
+    use crate::hash::hash_types::{HashOutTarget, RichField};
     use crate::hash::hashing::hash_n_to_hash_no_pad;
     use crate::hash::poseidon_goldilocks::{Poseidon64Hash, Poseidon64Permutation};
     use crate::iop::witness::{PartialWitness, WitnessWrite};
@@ -278,7 +279,7 @@ mod tests {
     /// - VK for cyclic recursion (?)
     #[test]
     fn test_cyclic_recursion() -> Result<()> {
-        const D: usize = 2;
+        const D: usize = GOLDILOCKS_EXTENSION_FIELD_DEGREE;
         type C = PoseidonGoldilocksConfig;
         const NUM_HASH_OUT_ELTS: usize = GOLDILOCKS_NUM_HASH_OUT_ELTS;
         type F = <C as GenericConfig<D, NUM_HASH_OUT_ELTS>>::F;

--- a/plonky2/src/recursion/recursive_verifier.rs
+++ b/plonky2/src/recursion/recursive_verifier.rs
@@ -219,6 +219,10 @@ mod tests {
     use p3_baby_bear::BabyBear;
     use p3_field::{AbstractField, PrimeField64};
     use p3_goldilocks::Goldilocks;
+    use plonky2_field::{
+        BABYBEAR_EXTENSION_FIELD_DEGREE, BABYBEAR_NUM_HASH_OUT_ELTS,
+        GOLDILOCKS_EXTENSION_FIELD_DEGREE, GOLDILOCKS_NUM_HASH_OUT_ELTS,
+    };
     use wasm_bindgen_test::wasm_bindgen_test;
 
     use super::*;
@@ -230,7 +234,6 @@ mod tests {
     use crate::gates::noop::NoopGate;
     use crate::gates::poseidon2_babybear::Poseidon2BabyBearGate;
     use crate::gates::poseidon_goldilocks::PoseidonGate;
-    use crate::hash::hash_types::{BABYBEAR_NUM_HASH_OUT_ELTS, GOLDILOCKS_NUM_HASH_OUT_ELTS};
     use crate::iop::witness::{PartialWitness, WitnessWrite};
     use crate::plonk::circuit_data::{CircuitConfig, VerifierOnlyCircuitData};
     use crate::plonk::config::{
@@ -249,7 +252,7 @@ mod tests {
     #[test]
     fn test_recursive_verifier_gl() -> Result<()> {
         init_logger();
-        const D: usize = 2;
+        const D: usize = GOLDILOCKS_EXTENSION_FIELD_DEGREE;
         type C = PoseidonGoldilocksConfig;
         const NUM_HASH_OUT_ELTS: usize = GOLDILOCKS_NUM_HASH_OUT_ELTS;
         type F = <C as GenericConfig<D, NUM_HASH_OUT_ELTS>>::F;
@@ -277,7 +280,7 @@ mod tests {
     #[test]
     #[wasm_bindgen_test]
     fn test_recursive_verifier_gl_regression() -> Result<()> {
-        const D: usize = 2;
+        const D: usize = GOLDILOCKS_EXTENSION_FIELD_DEGREE;
         type C = PoseidonGoldilocksConfig;
         const NUM_HASH_OUT_ELTS: usize = GOLDILOCKS_NUM_HASH_OUT_ELTS;
         type F = <C as GenericConfig<D, NUM_HASH_OUT_ELTS>>::F;
@@ -290,9 +293,11 @@ mod tests {
         .unwrap();
 
         // Deserialize verifier data
-        let verifier_data = VerifierOnlyCircuitData::<PoseidonGoldilocksConfig, 2, 4>::from_bytes(
-            RECURSIVE_VERIFIER_GL_VERIFIER_DATA.to_vec(),
-        )
+        let verifier_data = VerifierOnlyCircuitData::<
+            PoseidonGoldilocksConfig,
+            GOLDILOCKS_EXTENSION_FIELD_DEGREE,
+            GOLDILOCKS_NUM_HASH_OUT_ELTS,
+        >::from_bytes(RECURSIVE_VERIFIER_GL_VERIFIER_DATA.to_vec())
         .unwrap();
 
         // Deserialize the proof
@@ -311,7 +316,7 @@ mod tests {
     #[test]
     fn test_recursive_verifier_bb() -> Result<()> {
         init_logger();
-        const D: usize = 4;
+        const D: usize = BABYBEAR_EXTENSION_FIELD_DEGREE;
         type C = Poseidon2BabyBearConfig;
         const NUM_HASH_OUT_ELTS: usize = BABYBEAR_NUM_HASH_OUT_ELTS;
         type F = <C as GenericConfig<D, NUM_HASH_OUT_ELTS>>::F;
@@ -335,7 +340,7 @@ mod tests {
     #[test]
     fn test_recursive_verifier_one_lookup() -> Result<()> {
         init_logger();
-        const D: usize = 2;
+        const D: usize = GOLDILOCKS_EXTENSION_FIELD_DEGREE;
         type C = PoseidonGoldilocksConfig;
         const NUM_HASH_OUT_ELTS: usize = GOLDILOCKS_NUM_HASH_OUT_ELTS;
         type F = <C as GenericConfig<D, NUM_HASH_OUT_ELTS>>::F;
@@ -360,7 +365,7 @@ mod tests {
     #[test]
     fn test_recursive_verifier_two_luts() -> Result<()> {
         init_logger();
-        const D: usize = 2;
+        const D: usize = GOLDILOCKS_EXTENSION_FIELD_DEGREE;
         type C = PoseidonGoldilocksConfig;
         const NUM_HASH_OUT_ELTS: usize = GOLDILOCKS_NUM_HASH_OUT_ELTS;
         type F = <C as GenericConfig<D, NUM_HASH_OUT_ELTS>>::F;
@@ -384,7 +389,7 @@ mod tests {
     #[test]
     fn test_recursive_verifier_too_many_rows() -> Result<()> {
         init_logger();
-        const D: usize = 2;
+        const D: usize = GOLDILOCKS_EXTENSION_FIELD_DEGREE;
         type C = PoseidonGoldilocksConfig;
         const NUM_HASH_OUT_ELTS: usize = GOLDILOCKS_NUM_HASH_OUT_ELTS;
         type F = <C as GenericConfig<D, NUM_HASH_OUT_ELTS>>::F;
@@ -409,7 +414,7 @@ mod tests {
     #[test]
     fn test_recursive_recursive_verifier_gl() -> Result<()> {
         init_logger();
-        const D: usize = 2;
+        const D: usize = GOLDILOCKS_EXTENSION_FIELD_DEGREE;
         type C = PoseidonGoldilocksConfig;
         const NUM_HASH_OUT_ELTS: usize = GOLDILOCKS_NUM_HASH_OUT_ELTS;
         type F = <C as GenericConfig<D, NUM_HASH_OUT_ELTS>>::F;
@@ -480,7 +485,7 @@ mod tests {
     #[test]
     fn test_recursive_recursive_verifier_bb() -> Result<()> {
         init_logger();
-        const D: usize = 4;
+        const D: usize = BABYBEAR_EXTENSION_FIELD_DEGREE;
         type C = Poseidon2BabyBearConfig;
         const NUM_HASH_OUT_ELTS: usize = BABYBEAR_NUM_HASH_OUT_ELTS;
         type F = <C as GenericConfig<D, NUM_HASH_OUT_ELTS>>::F;
@@ -540,7 +545,7 @@ mod tests {
     #[ignore]
     fn test_size_optimized_recursion() -> Result<()> {
         init_logger();
-        const D: usize = 2;
+        const D: usize = GOLDILOCKS_EXTENSION_FIELD_DEGREE;
         type C = PoseidonGoldilocksConfig;
         const NUM_HASH_OUT_ELTS: usize = GOLDILOCKS_NUM_HASH_OUT_ELTS;
         type KC = KeccakGoldilocksConfig;
@@ -617,7 +622,7 @@ mod tests {
     #[test]
     fn test_recursive_verifier_multi_hash() -> Result<()> {
         init_logger();
-        const D: usize = 2;
+        const D: usize = GOLDILOCKS_EXTENSION_FIELD_DEGREE;
         const NUM_HASH_OUT_ELTS: usize = GOLDILOCKS_NUM_HASH_OUT_ELTS;
         type PC = PoseidonGoldilocksConfig;
         type KC = KeccakGoldilocksConfig;

--- a/plonky2/src/util/reducing.rs
+++ b/plonky2/src/util/reducing.rs
@@ -288,17 +288,17 @@ impl<const D: usize> ReducingFactorTarget<D> {
 mod tests {
     use anyhow::Result;
     use p3_field::AbstractField;
+    use plonky2_field::{GOLDILOCKS_EXTENSION_FIELD_DEGREE, GOLDILOCKS_NUM_HASH_OUT_ELTS};
 
     use super::*;
     use crate::field::types::Sample;
-    use crate::hash::hash_types::GOLDILOCKS_NUM_HASH_OUT_ELTS;
     use crate::iop::witness::{PartialWitness, WitnessWrite};
     use crate::plonk::circuit_data::CircuitConfig;
     use crate::plonk::config::{GenericConfig, PoseidonGoldilocksConfig};
     use crate::plonk::verifier::verify;
 
     fn test_reduce_gadget_base(n: usize) -> Result<()> {
-        const D: usize = 2;
+        const D: usize = GOLDILOCKS_EXTENSION_FIELD_DEGREE;
         type C = PoseidonGoldilocksConfig;
         const NUM_HASH_OUT_ELTS: usize = GOLDILOCKS_NUM_HASH_OUT_ELTS;
         type F = <C as GenericConfig<D, NUM_HASH_OUT_ELTS>>::F;
@@ -331,7 +331,7 @@ mod tests {
     }
 
     fn test_reduce_gadget(n: usize) -> Result<()> {
-        const D: usize = 2;
+        const D: usize = GOLDILOCKS_EXTENSION_FIELD_DEGREE;
         type C = PoseidonGoldilocksConfig;
         const NUM_HASH_OUT_ELTS: usize = GOLDILOCKS_NUM_HASH_OUT_ELTS;
         type F = <C as GenericConfig<D, NUM_HASH_OUT_ELTS>>::F;

--- a/plonky2/src/util/serialization/generator_serialization.rs
+++ b/plonky2/src/util/serialization/generator_serialization.rs
@@ -137,11 +137,11 @@ pub mod default {
     /// A generator serializer that can be used to serialize all default generators supported
     /// by the `plonky2` library. It can simply be called as
     /// ```rust
-    /// use plonky2::hash::hash_types::GOLDILOCKS_NUM_HASH_OUT_ELTS;
+    /// use plonky2_field::{GOLDILOCKS_NUM_HASH_OUT_ELTS, GOLDILOCKS_EXTENSION_FIELD_DEGREE};
     /// use plonky2::util::serialization::DefaultGeneratorSerializer;
     /// use plonky2::plonk::config::PoseidonGoldilocksConfig;
     ///
-    /// const D: usize = 2;
+    /// const D: usize = GOLDILOCKS_EXTENSION_FIELD_DEGREE;
     /// const NUM_HASH_OUT_ELTS: usize = GOLDILOCKS_NUM_HASH_OUT_ELTS;
     /// type C = PoseidonGoldilocksConfig;
     /// let generator_serializer = DefaultGeneratorSerializer::<C, D, NUM_HASH_OUT_ELTS>::default();


### PR DESCRIPTION
They are in the field package and they are used instead of magic numbers.