### PR TITLE
Fixed issue with num_challenges of the BabyBear configuration

### DIFF
--- a/plonky2/benches/recursion.rs
+++ b/plonky2/benches/recursion.rs
@@ -361,7 +361,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         Poseidon2BabyBearConfig,
         BABYBEAR_EXTENSION_FIELD_DEGREE,
         BABYBEAR_NUM_HASH_OUT_ELTS,
-    >(c, &CircuitConfig::standard_recursion_config_bb_wide());
+    >(c, &CircuitConfig::standard_recursion_config_bb());
 
     bench_merge::<
         Goldilocks,
@@ -374,7 +374,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         Poseidon2BabyBearConfig,
         BABYBEAR_EXTENSION_FIELD_DEGREE,
         BABYBEAR_NUM_HASH_OUT_ELTS,
-    >(c, &CircuitConfig::standard_recursion_config_bb_wide());
+    >(c, &CircuitConfig::standard_recursion_config_bb());
 }
 
 criterion_group!(benches, criterion_benchmark);

--- a/plonky2/examples/bench_recursion.rs
+++ b/plonky2/examples/bench_recursion.rs
@@ -409,7 +409,7 @@ fn main() -> Result<()> {
         Poseidon2BabyBearConfig,
         BABYBEAR_EXTENSION_FIELD_DEGREE,
         BABYBEAR_NUM_HASH_OUT_ELTS,
-    >(CircuitConfig::standard_recursion_config_bb_wide())?;
+    >(CircuitConfig::standard_recursion_config_bb())?;
     do_bench::<
         Goldilocks,
         PoseidonGoldilocksConfig,

--- a/plonky2/src/gates/gate_testing.rs
+++ b/plonky2/src/gates/gate_testing.rs
@@ -149,7 +149,7 @@ where
     let constants = F::Extension::rand_vec(gate.num_constants());
 
     let config = match F::ORDER_U64 {
-        p3_baby_bear::BabyBear::ORDER_U64 => CircuitConfig::standard_recursion_config_bb_wide(),
+        p3_baby_bear::BabyBear::ORDER_U64 => CircuitConfig::recursion_config_bb_wide(),
         _ => CircuitConfig::standard_recursion_config_gl(),
     };
     let mut pw = PartialWitness::new();

--- a/plonky2/src/gates/poseidon2_babybear.rs
+++ b/plonky2/src/gates/poseidon2_babybear.rs
@@ -31,6 +31,10 @@ use crate::plonk::config::AlgebraicHasher;
 use crate::plonk::vars::{EvaluationTargets, EvaluationVars, EvaluationVarsBase};
 use crate::util::serialization::{Buffer, IoResult, Read, Write};
 
+// These flags are used to choose between using a custom gate for the internal and external permutation
+// in the circuit. These reduces the number of gates in the recursive verifier and it is helpful
+// if the recursive verifier circuit has a number of gates close to a power of two.
+// Otherwise is worthless and it just makes the circuit more complex.
 const USE_INTERNAL_PERMUTATION_GATE: bool = false;
 const USE_EXTERNAL_PERMUTATION_GATE: bool = false;
 const SBOX_EXP: u64 = 7;

--- a/plonky2/src/gates/poseidon2_babybear.rs
+++ b/plonky2/src/gates/poseidon2_babybear.rs
@@ -1066,7 +1066,7 @@ mod tests {
         type EF = <F as HasExtension<D>>::Extension;
 
         let mut state: [EF; SPONGE_WIDTH] = EF::rand_array();
-        let config = CircuitConfig::standard_recursion_config_gl();
+        let config = CircuitConfig::standard_recursion_config_bb();
         let mut builder = CircuitBuilder::<F, D, NUM_HASH_OUT_ELTS>::new(config);
         let mut pw = PartialWitness::<F>::new();
         let mut state_target: [ExtensionTarget<D>; SPONGE_WIDTH] = builder

--- a/plonky2/src/gates/poseidon2_babybear.rs
+++ b/plonky2/src/gates/poseidon2_babybear.rs
@@ -31,8 +31,8 @@ use crate::plonk::config::AlgebraicHasher;
 use crate::plonk::vars::{EvaluationTargets, EvaluationVars, EvaluationVarsBase};
 use crate::util::serialization::{Buffer, IoResult, Read, Write};
 
-const USE_INTERNAL_PERMUTATION_GATE: bool = true;
-const USE_EXTERNAL_PERMUTATION_GATE: bool = true;
+const USE_INTERNAL_PERMUTATION_GATE: bool = false;
+const USE_EXTERNAL_PERMUTATION_GATE: bool = false;
 const SBOX_EXP: u64 = 7;
 pub(crate) const INTERNAL_DIAG_SHIFTS: [usize; SPONGE_WIDTH - 1] =
     [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 15];
@@ -957,7 +957,7 @@ mod tests {
         const NUM_HASH_OUT_ELTS: usize = BABYBEAR_NUM_HASH_OUT_ELTS;
         type F = <C as GenericConfig<D, NUM_HASH_OUT_ELTS>>::F;
 
-        let config = CircuitConfig::standard_recursion_config_bb_wide();
+        let config = CircuitConfig::standard_recursion_config_bb();
         let mut builder = CircuitBuilder::new(config.clone());
         type Gate = Poseidon2BabyBearGate<F, D>;
         let gate = Gate::new(&config);
@@ -1003,7 +1003,7 @@ mod tests {
     fn low_degree() {
         type F = BabyBear;
         let gate =
-            Poseidon2BabyBearGate::<F, 4>::new(&CircuitConfig::standard_recursion_config_bb_wide());
+            Poseidon2BabyBearGate::<F, 4>::new(&CircuitConfig::standard_recursion_config_bb());
         test_low_degree::<F, Poseidon2BabyBearGate<F, 4>, 4, 8>(gate)
     }
 
@@ -1014,7 +1014,7 @@ mod tests {
         const NUM_HASH_OUT_ELTS: usize = BABYBEAR_NUM_HASH_OUT_ELTS;
         type F = <C as GenericConfig<D, NUM_HASH_OUT_ELTS>>::F;
         let gate =
-            Poseidon2BabyBearGate::<F, D>::new(&CircuitConfig::standard_recursion_config_bb_wide());
+            Poseidon2BabyBearGate::<F, D>::new(&CircuitConfig::standard_recursion_config_bb());
         test_eval_fns::<F, C, _, D, NUM_HASH_OUT_ELTS>(gate)
     }
 
@@ -1042,7 +1042,7 @@ mod tests {
         type EF = <F as HasExtension<D>>::Extension;
 
         let mut state: [EF; SPONGE_WIDTH] = EF::rand_array();
-        let config = CircuitConfig::standard_recursion_config_bb_wide();
+        let config = CircuitConfig::standard_recursion_config_bb();
         let mut builder = CircuitBuilder::<F, D, NUM_HASH_OUT_ELTS>::new(config);
         let mut pw = PartialWitness::<F>::new();
         let mut state_target: [ExtensionTarget<D>; SPONGE_WIDTH] = builder

--- a/plonky2/src/gates/poseidon2_risc0_babybear.rs
+++ b/plonky2/src/gates/poseidon2_risc0_babybear.rs
@@ -61,9 +61,7 @@ impl<F: RichField + HasExtension<D>, const D: usize> Poseidon2R0BabyBearGate<F, 
         if BabyBear::ORDER_U64 != F::ORDER_U64 {
             panic!("The Poseidon2 BabyBear gate can be used only for the BabyBear field!")
         }
-        let wires_per_op = ROUTED_WIRES_PER_OP + NON_ROUTED_WIRES_PER_OP;
-        let num_ops =
-            (config.num_wires / wires_per_op).min(config.num_routed_wires / ROUTED_WIRES_PER_OP);
+        let num_ops = Self::num_ops(config);
         Self {
             num_ops,
             _phantom: PhantomData,

--- a/plonky2/src/gates/poseidon2_risc0_babybear.rs
+++ b/plonky2/src/gates/poseidon2_risc0_babybear.rs
@@ -994,7 +994,7 @@ mod tests {
         type EF = <F as HasExtension<D>>::Extension;
 
         let mut state: [EF; SPONGE_WIDTH] = EF::rand_array();
-        let config = CircuitConfig::standard_recursion_config_gl();
+        let config = CircuitConfig::standard_recursion_config_bb();
         let mut builder = CircuitBuilder::<F, D, NUM_HASH_OUT_ELTS>::new(config);
         let mut pw = PartialWitness::<F>::new();
         let mut state_target: [ExtensionTarget<D>; SPONGE_WIDTH] = builder

--- a/plonky2/src/hash/poseidon2_babybear.rs
+++ b/plonky2/src/hash/poseidon2_babybear.rs
@@ -235,7 +235,7 @@ mod tests {
         type H = Poseidon2BabyBearHash;
         type C = Poseidon2BabyBearConfig;
         let mut builder = CircuitBuilder::<F, D, NUM_HASH_OUT_ELTS>::new(
-            CircuitConfig::standard_recursion_config_bb_wide(),
+            CircuitConfig::standard_recursion_config_bb(),
         );
         let vec = F::rand_vec(NUM_HASH_OUT_ELTS * 3);
         let res = H::hash_or_noop(&vec);

--- a/plonky2/src/hash/poseidon2_risc0_babybear.rs
+++ b/plonky2/src/hash/poseidon2_risc0_babybear.rs
@@ -246,7 +246,8 @@ impl<F: RichField> AlgebraicHasher<F, 8> for Poseidon2R0BabyBearHash {
         F: HasExtension<D>,
         <F as HasExtension<D>>::Extension: TwoAdicField,
     {
-        let gate_type: Poseidon2R0BabyBearGate<F, D> = Poseidon2R0BabyBearGate::<F, D>::new();
+        let gate_type: Poseidon2R0BabyBearGate<F, D> =
+            Poseidon2R0BabyBearGate::<F, D>::new_from_config(&builder.config);
         let (row, op) = builder.find_slot(gate_type.clone(), &[], &[]);
 
         let swap_wire = Poseidon2R0BabyBearGate::<F, D>::wire_swap(op);
@@ -351,7 +352,7 @@ mod tests {
         type H = Poseidon2R0BabyBearHash;
         type C = Poseidon2BabyBearConfig;
         let mut builder = CircuitBuilder::<F, D, NUM_HASH_OUT_ELTS>::new(
-            CircuitConfig::standard_recursion_config_bb_wide(),
+            CircuitConfig::recursion_config_bb_wide(),
         );
         let vec = F::rand_vec(NUM_HASH_OUT_ELTS * 3);
         let vec_target = builder.add_virtual_targets(NUM_HASH_OUT_ELTS * 3);

--- a/plonky2/src/plonk/circuit_builder.rs
+++ b/plonky2/src/plonk/circuit_builder.rs
@@ -244,13 +244,13 @@ impl<F: RichField + HasExtension<D>, const D: usize, const NUM_HASH_OUT_ELTS: us
             verifier_data_public_input: None,
             random_wire: None,
         };
-        builder.check_config();
+        builder.check_fri_security_bits();
         builder
     }
 
     /// Assert that the configuration used to create this `CircuitBuilder` is consistent,
     /// i.e. that the different parameters meet the targeted security level.
-    fn check_config(&self) {
+    fn check_fri_security_bits(&self) {
         let &CircuitConfig {
             security_bits,
             fri_config:
@@ -1184,6 +1184,12 @@ where {
             fri_params.total_arities() <= degree_bits + rate_bits - cap_height,
             "FRI total reduction arity is too large.",
         );
+        assert!(
+            F::Extension::bits() - degree_bits >= self.config.security_bits,
+            "The degree of the extension is not enough for the soudness of the evaluation point!"
+        );
+        let soundness_bits = F::bits() - degree_bits;
+        assert!(soundness_bits * self.config.num_challenges >= self.config.security_bits, "The number of challenges is not sufficient for the soundness of permutation argument and combining constraints!");
 
         let quotient_degree_factor = self.config.max_quotient_degree_factor;
         let mut gates = self.gates.iter().cloned().collect::<Vec<_>>();

--- a/plonky2/src/plonk/circuit_data.rs
+++ b/plonky2/src/plonk/circuit_data.rs
@@ -100,24 +100,40 @@ impl CircuitConfig {
 
     /// A typical recursion config, without zero-knowledge, targeting ~100 bit security.
     pub fn standard_recursion_config_gl() -> Self {
+        let base = Self::standard_recursion_config();
         Self {
             num_wires: 135,
-            ..Self::standard_recursion_config()
+            num_challenges: 2,
+            fri_config: FriConfig {
+                reduction_strategy: FriReductionStrategy::ConstantArityBits(4, 5),
+                cap_height: base.fri_config.cap_height,
+                proof_of_work_bits: base.fri_config.proof_of_work_bits,
+                rate_bits: base.fri_config.rate_bits,
+                num_query_rounds: base.fri_config.num_query_rounds,
+            },
+            ..base
         }
     }
-    pub fn standard_recursion_config_bb_wide() -> Self {
+
+    pub fn standard_recursion_config_bb() -> Self {
+        Self::recursion_config_bb_narrow()
+    }
+
+    pub fn recursion_config_bb_wide() -> Self {
         Self {
             //num_wires: Poseidon2BabyBearGate::<BabyBear,4>::end() + 1, num_routed_wires: 160,
             num_wires: 334,
             num_routed_wires: 160,
+            num_challenges: 6,
             ..Self::standard_recursion_config()
         }
     }
-    pub fn standard_recursion_config_bb_narrow() -> Self {
+    pub fn recursion_config_bb_narrow() -> Self {
         Self {
             //num_wires: Poseidon2BabyBearGate::<BabyBear,4>::end() + 1, num_routed_wires: 160,
             num_wires: 167,
-            num_routed_wires: 128,
+            num_routed_wires: 41,
+            num_challenges: 6,
             ..Self::standard_recursion_config()
         }
     }
@@ -129,14 +145,14 @@ impl CircuitConfig {
             num_constants: 2,
             use_base_arithmetic_gate: true,
             security_bits: 100,
-            num_challenges: 2,
+            num_challenges: 0,
             zero_knowledge: false,
             max_quotient_degree_factor: 8,
             fri_config: FriConfig {
                 rate_bits: 3,
                 cap_height: 4,
                 proof_of_work_bits: 16,
-                reduction_strategy: FriReductionStrategy::ConstantArityBits(4, 5),
+                reduction_strategy: FriReductionStrategy::ConstantArityBits(3, 5),
                 num_query_rounds: 28,
             },
         }
@@ -165,7 +181,7 @@ impl CircuitConfig {
     pub fn standard_recursion_zk_config_bb() -> Self {
         CircuitConfig {
             zero_knowledge: true,
-            ..Self::standard_recursion_config_bb_wide()
+            ..Self::standard_recursion_config_bb()
         }
     }
 }

--- a/plonky2/src/plonk/proof.rs
+++ b/plonky2/src/plonk/proof.rs
@@ -627,7 +627,7 @@ mod tests {
             const NUM_HASH_OUT_ELTS: usize = BABYBEAR_NUM_HASH_OUT_ELTS;
             type F = <C as GenericConfig<D, NUM_HASH_OUT_ELTS>>::F;
 
-            let config = CircuitConfig::standard_recursion_config_bb_wide();
+            let config = CircuitConfig::standard_recursion_config_bb();
 
             let mut builder = CircuitBuilder::<F, D, NUM_HASH_OUT_ELTS>::new(config);
             let xt = builder.add_virtual_target();

--- a/plonky2/src/recursion/recursive_verifier.rs
+++ b/plonky2/src/recursion/recursive_verifier.rs
@@ -320,7 +320,7 @@ mod tests {
         type C = Poseidon2BabyBearConfig;
         const NUM_HASH_OUT_ELTS: usize = BABYBEAR_NUM_HASH_OUT_ELTS;
         type F = <C as GenericConfig<D, NUM_HASH_OUT_ELTS>>::F;
-        let config = CircuitConfig::standard_recursion_zk_config_bb();
+        let config = CircuitConfig::standard_recursion_config_bb();
 
         let (proof, vd, common_data) = dummy_proof::<F, C, D, NUM_HASH_OUT_ELTS>(&config, 4_000)?;
         let (proof, vd, common_data) = recursive_proof::<F, C, C, D, NUM_HASH_OUT_ELTS>(

--- a/plonky2/src/recursion/recursive_verifier.rs
+++ b/plonky2/src/recursion/recursive_verifier.rs
@@ -490,7 +490,7 @@ mod tests {
         const NUM_HASH_OUT_ELTS: usize = BABYBEAR_NUM_HASH_OUT_ELTS;
         type F = <C as GenericConfig<D, NUM_HASH_OUT_ELTS>>::F;
 
-        let config = CircuitConfig::standard_recursion_config_bb_wide();
+        let config = CircuitConfig::standard_recursion_config_bb();
         info!(" ****************  Generating Dummy Proof ****************");
         // Start with a degree 2^14 proof
         let (proof, vd, common_data) = dummy_proof::<F, C, D, NUM_HASH_OUT_ELTS>(&config, 16_000)?;
@@ -520,7 +520,7 @@ mod tests {
             true,
             true,
         )?;
-        assert_eq!(common_data.degree_bits(), 12);
+        assert_eq!(common_data.degree_bits(), 13);
 
         info!(" ****************  Generating 3rd Recursive Proof ****************");
         // Shrink it to 2^12.
@@ -533,7 +533,7 @@ mod tests {
             true,
             true,
         )?;
-        assert_eq!(common_data.degree_bits(), 12);
+        assert_eq!(common_data.degree_bits(), 13);
 
         test_serialization(&proof, &vd, &common_data)?;
 


### PR DESCRIPTION
Permutation argument and combining constraints using a single challenge from a field `F` have a soundness error  `e = degree / |F|`  (see section 3.4 of Plonky2 document).  This error is too large for practical usage, so we need `n` challenges to reduce the error to `e^n`.
While `n=2` is ok for the targeted security bits for Goldilocks, it is far from being sufficient for BabyBear: if, for example, `degree = 2^14` we need at least 6 challenges to achieve 100 bits security: `((2^14)/(2^31))^6 = 2 ^ (-102)`.
The increases in the number of challenges unfortunately causes the impossibility to achieve` 2^12` rows for the circuit of the recursive verifier, so it's convenient to use a narrow configuration as default, having a recursive verifier circuit with `2^13` rows.